### PR TITLE
remove runAtTime

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,7 +38,7 @@ export default [
         {
           argsIgnorePattern: "^_",
           varsIgnorePattern: "^_",
-          "caughtErrorsIgnorePattern": "^_",
+          caughtErrorsIgnorePattern: "^_",
         },
       ],
     },

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -56,7 +56,7 @@ export declare const components: {
           fnArgs: any;
           fnHandle: string;
           fnName: string;
-          fnType: "action" | "mutation" | "unknown";
+          fnType: "action" | "mutation";
           options: {
             actionTimeoutMs?: number;
             debounceMs?: number;
@@ -66,9 +66,7 @@ export declare const components: {
             mutationTimeoutMs?: number;
             slowHeartbeatMs?: number;
             ttl?: number;
-            unknownTimeoutMs?: number;
           };
-          runAtTime: number;
         },
         string
       >;
@@ -104,7 +102,7 @@ export declare const components: {
           fnArgs: any;
           fnHandle: string;
           fnName: string;
-          fnType: "action" | "mutation" | "unknown";
+          fnType: "action" | "mutation";
           options: {
             actionTimeoutMs?: number;
             debounceMs?: number;
@@ -114,9 +112,7 @@ export declare const components: {
             mutationTimeoutMs?: number;
             slowHeartbeatMs?: number;
             ttl?: number;
-            unknownTimeoutMs?: number;
           };
-          runAtTime: number;
         },
         string
       >;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -79,7 +79,6 @@ export class WorkPool {
       fnName: getFunctionName(fn),
       fnArgs,
       fnType: "action",
-      runAtTime: Date.now(),
       options: this.options,
     });
     return id as WorkId;
@@ -95,31 +94,6 @@ export class WorkPool {
       fnName: getFunctionName(fn),
       fnArgs,
       fnType: "mutation",
-      runAtTime: Date.now(),
-      options: this.options,
-    });
-    return id as WorkId;
-  }
-  // Unknown is if you don't know at runtime whether it's an action or mutation,
-  // which can happen if it comes from `runAt` or `runAfter`.
-  async enqueueUnknown<Args extends DefaultFunctionArgs>(
-    ctx: RunMutationCtx,
-    fn: FunctionReference<
-      "action" | "mutation",
-      FunctionVisibility,
-      Args,
-      null
-    >,
-    fnArgs: Args,
-    runAtTime: number
-  ): Promise<WorkId> {
-    const fnHandle = await createFunctionHandle(fn);
-    const id = await ctx.runMutation(this.component.lib.enqueue, {
-      fnHandle,
-      fnName: getFunctionName(fn),
-      fnArgs,
-      fnType: "unknown",
-      runAtTime,
       options: this.options,
     });
     return id as WorkId;

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -41,7 +41,7 @@ export type Mounts = {
         fnArgs: any;
         fnHandle: string;
         fnName: string;
-        fnType: "action" | "mutation" | "unknown";
+        fnType: "action" | "mutation";
         options: {
           actionTimeoutMs?: number;
           debounceMs?: number;
@@ -51,9 +51,7 @@ export type Mounts = {
           mutationTimeoutMs?: number;
           slowHeartbeatMs?: number;
           ttl?: number;
-          unknownTimeoutMs?: number;
         };
-        runAtTime: number;
       },
       string
     >;

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -48,7 +48,6 @@ export default defineSchema({
     maxParallelism: v.number(),
     actionTimeoutMs: v.number(),
     mutationTimeoutMs: v.number(),
-    unknownTimeoutMs: v.number(),
     debounceMs: v.number(),
     fastHeartbeatMs: v.number(),
     slowHeartbeatMs: v.number(),
@@ -69,16 +68,11 @@ export default defineSchema({
   }).index("runAtTime", ["runAtTime"]),
 
   pendingWork: defineTable({
-    fnType: v.union(
-      v.literal("action"),
-      v.literal("mutation"),
-      v.literal("unknown")
-    ),
+    fnType: v.union(v.literal("action"), v.literal("mutation")),
     fnHandle: v.string(),
     fnName: v.string(),
     fnArgs: v.any(),
-    runAtTime: v.number(),
-  }).index("runAtTime", ["runAtTime"]),
+  }),
   pendingCompletion: defineTable({
     completionStatus,
     workId: v.id("pendingWork"),

--- a/src/component/stats.ts
+++ b/src/component/stats.ts
@@ -22,8 +22,7 @@ workpool
 export function recordStarted(
   workId: Id<"pendingWork">,
   fnName: string,
-  enqueuedAt: number,
-  runAtTime: number
+  enqueuedAt: number
 ) {
   console.log(
     JSON.stringify({
@@ -31,7 +30,6 @@ export function recordStarted(
       event: "started",
       fnName,
       enqueuedAt,
-      runAtTime,
       startedAt: Date.now(),
       lagSinceEnqueued: Date.now() - enqueuedAt,
     })


### PR DESCRIPTION
<!-- Describe your PR here. -->

pare down the interface by removing the runAtTime param, which was only used when we tried to emulate `ctx.scheduler`. instead we will just support things to run immediately.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
