### PR TITLE
change mainLoop to hold status, not timestamp

### DIFF
--- a/src/component/stats.ts
+++ b/src/component/stats.ts
@@ -20,7 +20,7 @@ workpool
  */
 
 export function recordStarted(
-  workId: Id<"pendingWork">,
+  workId: Id<"work">,
   fnName: string,
   enqueuedAt: number
 ) {
@@ -37,7 +37,7 @@ export function recordStarted(
 }
 
 export function recordCompleted(
-  workId: Id<"pendingWork">,
+  workId: Id<"work">,
   status: "success" | "error" | "canceled" | "timeout"
 ) {
   console.log(JSON.stringify({ workId, completedAt: Date.now(), status }));


### PR DESCRIPTION
<!-- Describe your PR here. -->

change the "mainLoop" table to just hold a state of whether it's running, scheduled, or idle. it doesn't need a runAtTime because that's just annoying to keep updated and causes OCCs

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
