### PR TITLE
Ian/review

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,7 @@ export default app;
 import { components } from "./_generated/api";
 import { Workpool } from "@convex-dev/workpool";
 
-const pool = new Workpool(components.emailWorkpool, {
-  maxParallelism: 10,
-  // More options available, such as:
-  ttl: 7 * 24 * 60 * 60 * 1000,
-});
+const pool = new Workpool(components.emailWorkpool, { maxParallelism: 10 });
 ```
 
 Then you have the following interface on `pool`:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Then you have the following interface on `pool`:
 ```ts
 // Schedule functions to run in the background.
 const id = await pool.enqueueMutation(internal.foo.bar, args);
-const id = await pool.enqueueAction(internal.foo.bar, args);
+// Or for an action:
+const id = await pool.enqueueAction(internal.foo.baz, args);
 
 // Is it done yet? Did it succeed or fail?
 const status = await pool.status(id);

--- a/README.md
+++ b/README.md
@@ -155,4 +155,29 @@ alternatives to Workpool:
 
 See [best practices](https://docs.convex.dev/production/best-practices) for more.
 
+## Reading function status
+
+The workpool stores the status of each function in the database, so you can
+read it even after the function has finished.
+By default, it will keep the status for 1 day but you can change this with
+the `statusTtl` option to `Workpool`.
+
+To keep the status forever, set `statusTtl: Number.POSITIVE_INFINITY`.
+
+You can read the status of a function by calling `pool.status(id)`.
+
+The status will be one of:
+
+- `{ kind: "pending" }`: The function has not started yet.
+- `{ kind: "inProgress" }`: The function is currently running.
+- `{ kind: "completed"; completionStatus: CompletionStatus }`: The function has
+  finished.
+
+The `CompletionStatus` type is one of:
+
+- `"success"`: The function completed successfully.
+- `"error"`: The function threw an error.
+- `"canceled"`: The function was canceled.
+- `"timeout"`: The function timed out.
+
 <!-- END: Include on https://convex.dev/components -->

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -78,10 +78,6 @@ export declare const components: {
       >;
       stopCleanup: FunctionReference<"mutation", "internal", {}, any>;
     };
-    stats: {
-      debugCounts: FunctionReference<"query", "internal", {}, any>;
-      queueLength: FunctionReference<"query", "internal", {}, number>;
-    };
   };
   lowpriWorkpool: {
     lib: {
@@ -121,10 +117,6 @@ export declare const components: {
       >;
       stopCleanup: FunctionReference<"mutation", "internal", {}, any>;
     };
-    stats: {
-      debugCounts: FunctionReference<"query", "internal", {}, any>;
-      queueLength: FunctionReference<"query", "internal", {}, number>;
-    };
   };
   highPriWorkpool: {
     lib: {
@@ -163,10 +155,6 @@ export declare const components: {
           }
       >;
       stopCleanup: FunctionReference<"mutation", "internal", {}, any>;
-    };
-    stats: {
-      debugCounts: FunctionReference<"query", "internal", {}, any>;
-      queueLength: FunctionReference<"query", "internal", {}, number>;
     };
   };
 };

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -65,6 +65,7 @@ export declare const components: {
         },
         string
       >;
+      queueLength: FunctionReference<"query", "internal", {}, number>;
       status: FunctionReference<
         "query",
         "internal",
@@ -104,6 +105,7 @@ export declare const components: {
         },
         string
       >;
+      queueLength: FunctionReference<"query", "internal", {}, number>;
       status: FunctionReference<
         "query",
         "internal",
@@ -143,6 +145,7 @@ export declare const components: {
         },
         string
       >;
+      queueLength: FunctionReference<"query", "internal", {}, number>;
       status: FunctionReference<
         "query",
         "internal",

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -65,7 +65,6 @@ export declare const components: {
         },
         string
       >;
-      queueLength: FunctionReference<"query", "internal", {}, number>;
       status: FunctionReference<
         "query",
         "internal",
@@ -78,6 +77,10 @@ export declare const components: {
           }
       >;
       stopCleanup: FunctionReference<"mutation", "internal", {}, any>;
+    };
+    stats: {
+      debugCounts: FunctionReference<"query", "internal", {}, any>;
+      queueLength: FunctionReference<"query", "internal", {}, number>;
     };
   };
   lowpriWorkpool: {
@@ -105,7 +108,6 @@ export declare const components: {
         },
         string
       >;
-      queueLength: FunctionReference<"query", "internal", {}, number>;
       status: FunctionReference<
         "query",
         "internal",
@@ -118,6 +120,10 @@ export declare const components: {
           }
       >;
       stopCleanup: FunctionReference<"mutation", "internal", {}, any>;
+    };
+    stats: {
+      debugCounts: FunctionReference<"query", "internal", {}, any>;
+      queueLength: FunctionReference<"query", "internal", {}, number>;
     };
   };
   highPriWorkpool: {
@@ -145,7 +151,6 @@ export declare const components: {
         },
         string
       >;
-      queueLength: FunctionReference<"query", "internal", {}, number>;
       status: FunctionReference<
         "query",
         "internal",
@@ -158,6 +163,10 @@ export declare const components: {
           }
       >;
       stopCleanup: FunctionReference<"mutation", "internal", {}, any>;
+    };
+    stats: {
+      debugCounts: FunctionReference<"query", "internal", {}, any>;
+      queueLength: FunctionReference<"query", "internal", {}, number>;
     };
   };
 };

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -65,7 +65,6 @@ export declare const components: {
         },
         string
       >;
-      startMainLoop: FunctionReference<"mutation", "internal", {}, any>;
       status: FunctionReference<
         "query",
         "internal",
@@ -105,7 +104,6 @@ export declare const components: {
         },
         string
       >;
-      startMainLoop: FunctionReference<"mutation", "internal", {}, any>;
       status: FunctionReference<
         "query",
         "internal",
@@ -145,7 +143,6 @@ export declare const components: {
         },
         string
       >;
-      startMainLoop: FunctionReference<"mutation", "internal", {}, any>;
       status: FunctionReference<
         "query",
         "internal",

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -60,7 +60,7 @@ export declare const components: {
           options: {
             logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR";
             maxParallelism: number;
-            ttl?: number;
+            statusTtl?: number;
           };
         },
         string
@@ -100,7 +100,7 @@ export declare const components: {
           options: {
             logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR";
             maxParallelism: number;
-            ttl?: number;
+            statusTtl?: number;
           };
         },
         string
@@ -140,7 +140,7 @@ export declare const components: {
           options: {
             logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR";
             maxParallelism: number;
-            ttl?: number;
+            statusTtl?: number;
           };
         },
         string

--- a/example/convex/crons.ts
+++ b/example/convex/crons.ts
@@ -1,18 +1,19 @@
 import { cronJobs } from "convex/server";
-import { internal } from "./_generated/api";
+// import { internal } from "./_generated/api";
 
 const crons = cronJobs();
 
-crons.interval(
-  "start background work",
-  { minutes: 1 }, // every minute
-  internal.example.startBackgroundWork
-);
+// Useful for testing while developing.
+// crons.interval(
+//   "start background work",
+//   { minutes: 1 }, // every minute
+//   internal.example.startBackgroundWork
+// );
 
-crons.interval(
-  "start foreground work",
-  { seconds: 20 }, // every 20 seconds
-  internal.example.startForegroundWork
-);
+// crons.interval(
+//   "start foreground work",
+//   { seconds: 20 }, // every 20 seconds
+//   internal.example.startForegroundWork
+// );
 
 export default crons;

--- a/example/convex/crons.ts
+++ b/example/convex/crons.ts
@@ -3,7 +3,7 @@ import { cronJobs } from "convex/server";
 
 const crons = cronJobs();
 
-// Useful for testing while developing.
+// /* Useful for testing while developing.*/
 // crons.interval(
 //   "start background work",
 //   { minutes: 1 }, // every minute

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -137,7 +137,8 @@ export const echo = query({
 });
 
 async function sampleWork() {
-  const index = Math.floor(Math.random() * 3000) + 1;
+  const index = Math.floor(Math.random() * 1000) + 1;
+  await new Promise((resolve) => setTimeout(resolve, Math.random() * index));
   const url = `${process.env.CONVEX_CLOUD_URL}/api/query`;
   const start = Date.now();
   const response = await fetch(url, {

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -12,19 +12,19 @@ import { v } from "convex/values";
 const highPriPool = new Workpool(components.highPriWorkpool, {
   maxParallelism: 20,
   // For tests, disable completed work cleanup.
-  ttl: Number.POSITIVE_INFINITY,
+  statusTtl: Number.POSITIVE_INFINITY,
   logLevel: "INFO",
 });
 const pool = new Workpool(components.workpool, {
   maxParallelism: 3,
   // For tests, disable completed work cleanup.
-  ttl: Number.POSITIVE_INFINITY,
+  statusTtl: Number.POSITIVE_INFINITY,
   logLevel: "INFO",
 });
 const lowpriPool = new Workpool(components.lowpriWorkpool, {
   maxParallelism: 1,
   // For tests, disable completed work cleanup.
-  ttl: Number.POSITIVE_INFINITY,
+  statusTtl: Number.POSITIVE_INFINITY,
   logLevel: "INFO",
 });
 

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -122,7 +122,7 @@ export const enqueueABunchOfActions = action({
   },
 });
 
-export const enqueueAnAction = action({
+export const enqueueAnAction = mutation({
   args: {},
   handler: async (ctx, _args): Promise<void> => {
     await pool.enqueueAction(ctx, api.example.addAction, {});

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -184,6 +184,10 @@ export const foregroundWork = internalAction({
 export const startForegroundWork = internalMutation({
   args: {},
   handler: async (ctx, _args) => {
-    await pool.enqueueAction(ctx, internal.example.foregroundWork, {});
+    await Promise.all(
+      Array.from({ length: 20 }, () =>
+        highPriPool.enqueueAction(ctx, internal.example.foregroundWork, {})
+      )
+    );
   },
 });

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -73,12 +73,14 @@ export const status = query({
   },
 });
 
-export const enqueueABunchOfMutations = mutation({
+export const enqueueABunchOfMutations = action({
   args: {},
   handler: async (ctx, _args) => {
-    for (let i = 0; i < 30; i++) {
-      await pool.enqueueMutation(ctx, api.example.addMutation, {});
-    }
+    await Promise.all(
+      Array.from({ length: 30 }, () =>
+        pool.enqueueMutation(ctx, api.example.addMutation, {})
+      )
+    );
   },
 });
 
@@ -91,12 +93,14 @@ export const addLowPri = mutation({
   },
 });
 
-export const enqueueLowPriMutations = mutation({
+export const enqueueLowPriMutations = action({
   args: {},
   handler: async (ctx, _args) => {
-    for (let i = 0; i < 30; i++) {
-      await lowpriPool.enqueueMutation(ctx, api.example.addLowPri, {});
-    }
+    await Promise.all(
+      Array.from({ length: 30 }, () =>
+        lowpriPool.enqueueMutation(ctx, api.example.addLowPri, {})
+      )
+    );
   },
 });
 
@@ -107,12 +111,14 @@ export const highPriMutation = mutation({
   },
 });
 
-export const enqueueABunchOfActions = mutation({
+export const enqueueABunchOfActions = action({
   args: {},
   handler: async (ctx, _args) => {
-    for (let i = 0; i < 30; i++) {
-      await pool.enqueueAction(ctx, api.example.addAction, {});
-    }
+    await Promise.all(
+      Array.from({ length: 30 }, () =>
+        pool.enqueueAction(ctx, api.example.addAction, {})
+      )
+    );
   },
 });
 
@@ -156,12 +162,14 @@ export const backgroundWork = internalAction({
   },
 });
 
-export const startBackgroundWork = internalMutation({
+export const startBackgroundWork = internalAction({
   args: {},
   handler: async (ctx, _args) => {
-    for (let i = 0; i < 20; i++) {
-      await lowpriPool.enqueueAction(ctx, internal.example.backgroundWork, {});
-    }
+    await Promise.all(
+      Array.from({ length: 20 }, () =>
+        lowpriPool.enqueueAction(ctx, internal.example.backgroundWork, {})
+      )
+    );
   },
 });
 

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -123,13 +123,29 @@ export const enqueueAnAction = action({
   },
 });
 
+export const echo = query({
+  args: { num: v.number() },
+  handler: async (ctx, { num }) => {
+    return num;
+  },
+});
+
 async function sampleWork() {
   const index = Math.floor(Math.random() * 3000) + 1;
-  const url = `https://xkcd.com/${index}`;
-  const response = await fetch(url);
-  const text = await response.text();
-  const titleMatch = text.match(/<title>(.*)<\/title>/);
-  console.log(`xkcd ${index} title: ${titleMatch?.[1]}`);
+  const url = `${process.env.CONVEX_CLOUD_URL}/api/query`;
+  const start = Date.now();
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      path: "example:echo",
+      args: { num: index },
+    }),
+  });
+  const data = await response.json();
+  console.log(data.value === index, Date.now() - start);
 }
 
 // Example background work: scraping from a website.

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "version": "0.0.0",
   "scripts": {
-    "dev": "convex dev --live-component-sources --tail-logs",
+    "dev": "convex dev --live-component-sources",
     "dev:frontend": "vite",
     "logs": "convex logs",
     "lint": "tsc -p convex && eslint convex"

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "version": "0.0.0",
   "scripts": {
-    "dev": "convex dev --live-component-sources",
+    "dev": "convex dev --live-component-sources --tail-logs",
     "dev:frontend": "vite",
     "logs": "convex logs",
     "lint": "tsc -p convex && eslint convex"

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -35,7 +35,7 @@ export class Workpool {
       /** How long to keep completed work in the database, for access by `status`.
        * Default 1 day.
        */
-      ttl?: number;
+      statusTtl?: number;
     }
   ) {}
   async enqueueAction<Args extends DefaultFunctionArgs, ReturnType>(

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -12,7 +12,8 @@ import {
 import { GenericId } from "convex/values";
 import { api } from "../component/_generated/api";
 import { LogLevel } from "../component/logging";
-import { CompletionStatus } from "../component/schema";
+import { completionStatus, type CompletionStatus } from "../component/schema";
+export { completionStatus, type CompletionStatus };
 
 export type WorkId = string;
 

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -50,7 +50,6 @@ export type Mounts = {
       },
       string
     >;
-    startMainLoop: FunctionReference<"mutation", "public", {}, any>;
     status: FunctionReference<
       "query",
       "public",

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -50,7 +50,6 @@ export type Mounts = {
       },
       string
     >;
-    queueLength: FunctionReference<"query", "public", {}, number>;
     status: FunctionReference<
       "query",
       "public",
@@ -63,6 +62,10 @@ export type Mounts = {
         }
     >;
     stopCleanup: FunctionReference<"mutation", "public", {}, any>;
+  };
+  stats: {
+    debugCounts: FunctionReference<"query", "public", {}, any>;
+    queueLength: FunctionReference<"query", "public", {}, number>;
   };
 };
 // For now fullApiWithMounts is only fullApi which provides

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -50,6 +50,7 @@ export type Mounts = {
       },
       string
     >;
+    queueLength: FunctionReference<"query", "public", {}, number>;
     status: FunctionReference<
       "query",
       "public",

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -63,10 +63,6 @@ export type Mounts = {
     >;
     stopCleanup: FunctionReference<"mutation", "public", {}, any>;
   };
-  stats: {
-    debugCounts: FunctionReference<"query", "public", {}, any>;
-    queueLength: FunctionReference<"query", "public", {}, number>;
-  };
 };
 // For now fullApiWithMounts is only fullApi which provides
 // jump-to-definition in component client code.

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -45,7 +45,7 @@ export type Mounts = {
         options: {
           logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR";
           maxParallelism: number;
-          ttl?: number;
+          statusTtl?: number;
         };
       },
       string

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -590,3 +590,12 @@ async function ensureCleanupCron(ctx: MutationCtx, ttl: number) {
     );
   }
 }
+
+export const queueLength = query({
+  args: {},
+  returns: v.number(),
+  handler: async (ctx) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (ctx.db.query("pendingStart") as any).count();
+  },
+});

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -345,6 +345,7 @@ export const saveResult = internalMutation({
     workId: v.id("work"),
     result: v.optional(v.any()),
     error: v.optional(v.string()),
+    completionStatus,
   },
   handler: saveResultHandler,
 });

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -95,17 +95,16 @@ export const mainLoop = internalMutation({
     console_.time("[mainLoop] inProgress count");
     // This is the only function reading and writing inProgressWork,
     // and it's bounded by MAX_POSSIBLE_PARALLELISM, so we can
-    // read it all into memory.
-    const inProgressBefore = await ctx.db.query("inProgressWork").collect();
-    console_.debug(`[mainLoop] ${inProgressBefore.length} in progress`);
+    // read it all.
+    const inProgressBefore =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (ctx.db.query("inProgressWork") as any).count();
+    console_.debug(`[mainLoop] ${inProgressBefore} in progress`);
     console_.timeEnd("[mainLoop] inProgress count");
 
     // Move from pendingWork to inProgressWork.
     console_.time("[mainLoop] pendingWork");
-    const toSchedule = Math.min(
-      maxParallelism - inProgressBefore.length,
-      BATCH_SIZE
-    );
+    const toSchedule = Math.min(maxParallelism - inProgressBefore, BATCH_SIZE);
     let didSomething = false;
     const pending = await ctx.db.query("pendingStart").take(toSchedule);
     console_.debug(`[mainLoop] scheduling ${pending.length} pending work`);

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -243,10 +243,6 @@ async function beginWork(
   scheduledId: Id<"_scheduled_functions">;
   timeoutMs: number | null;
 }> {
-  const options = await getOptions(ctx.db);
-  if (!options) {
-    throw new Error("cannot begin work with no pool");
-  }
   const console_ = await console(ctx);
   const work = await ctx.db.get(pendingStart.workId);
   if (!work) {
@@ -362,10 +358,6 @@ async function saveResultHandler(
     completionStatus: "success" | "error" | "canceled" | "timeout";
   }
 ): Promise<void> {
-  const options = await getOptions(ctx.db);
-  if (!options) {
-    throw new Error("cannot save result with no pool");
-  }
   await ctx.db.insert("pendingCompletion", {
     completionStatus,
     workId,

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -91,6 +91,7 @@ export const mainLoop = internalMutation({
       throw new Error("no pool in mainLoop");
     }
     const { maxParallelism } = options;
+    let didSomething = false;
 
     console_.time("[mainLoop] inProgress count");
     // This is the only function reading and writing inProgressWork,
@@ -102,11 +103,7 @@ export const mainLoop = internalMutation({
 
     // Move from pendingWork to inProgressWork.
     console_.time("[mainLoop] pendingWork");
-    const toSchedule = Math.min(
-      maxParallelism - inProgressBefore.length,
-      BATCH_SIZE
-    );
-    let didSomething = false;
+    const toSchedule = maxParallelism - inProgressBefore.length;
     const pending = await ctx.db.query("pendingStart").take(toSchedule);
     console_.debug(`[mainLoop] scheduling ${pending.length} pending work`);
     await Promise.all(

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -110,14 +110,14 @@ export const mainLoop = internalMutation({
     const pending = await ctx.db.query("pendingStart").take(toSchedule);
     console_.debug(`[mainLoop] scheduling ${pending.length} pending work`);
     await Promise.all(
-      pending.map(async (work) => {
-        const { scheduledId, timeoutMs } = await beginWork(ctx, work);
+      pending.map(async (pendingWork) => {
+        const { scheduledId, timeoutMs } = await beginWork(ctx, pendingWork);
         await ctx.db.insert("inProgressWork", {
           running: scheduledId,
           timeoutMs,
-          workId: work.workId,
+          workId: pendingWork.workId,
         });
-        await ctx.db.delete(work._id);
+        await ctx.db.delete(pendingWork._id);
         didSomething = true;
       })
     );

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -149,7 +149,9 @@ export const mainLoop = internalMutation({
           workId: pendingCompletion.workId,
         });
         const work = (await ctx.db.get(pendingCompletion.workId))!;
-        console_.info(recordCompleted(work, pendingCompletion.completionStatus));
+        console_.info(
+          recordCompleted(work, pendingCompletion.completionStatus)
+        );
         didSomething = true;
       })
     );

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -66,10 +66,6 @@ export const cancel = mutation({
   },
 });
 
-async function getOptions(db: DatabaseReader) {
-  return db.query("pool").unique();
-}
-
 async function console(ctx: QueryCtx | ActionCtx) {
   if ("runAction" in ctx) {
     return globalThis.console;
@@ -90,10 +86,9 @@ export const mainLoop = internalMutation({
   handler: async (ctx, _args) => {
     const console_ = await console(ctx);
 
-    const options = await getOptions(ctx.db);
+    const options = (await ctx.db.query("pool").unique())!;
     if (!options) {
-      console_.info("[mainLoop] no pool, skipping mainLoop");
-      return;
+      throw new Error("no pool in mainLoop");
     }
     const { maxParallelism } = options;
 

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -1,7 +1,6 @@
 import { v } from "convex/values";
 import {
   ActionCtx,
-  DatabaseReader,
   internalAction,
   internalMutation,
   mutation,

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -417,11 +417,6 @@ async function startMainLoopHandler(ctx: MutationCtx, source: string) {
   await ctx.scheduler.runAfter(0, internal.lib.mainLoop, {});
 }
 
-export const startMainLoop = mutation({
-  args: {},
-  handler: (ctx) => startMainLoopHandler(ctx, "startMainLoop"),
-});
-
 export const stopCleanup = mutation({
   args: {},
   handler: async (ctx) => {

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -31,7 +31,7 @@ export const enqueue = mutation({
     options: v.object({
       maxParallelism: v.number(),
       logLevel: v.optional(logLevel),
-      ttl: v.optional(v.number()),
+      statusTtl: v.optional(v.number()),
     }),
   },
   returns: v.id("work"),
@@ -40,7 +40,7 @@ export const enqueue = mutation({
       ctx,
       {
         maxParallelism: options.maxParallelism,
-        ttl: options.ttl ?? 24 * 60 * 60 * 1000,
+        statusTtl: options.statusTtl ?? 24 * 60 * 60 * 1000,
         logLevel: options.logLevel ?? "WARN",
       },
       "enqueue"
@@ -586,7 +586,7 @@ async function ensurePoolExists(
     await ctx.db.insert("pools", opts);
     await startMainLoopHandler(ctx, source);
   }
-  await ensureCleanupCron(ctx, opts.ttl);
+  await ensureCleanupCron(ctx, opts.statusTtl);
 }
 
 async function ensureCleanupCron(ctx: MutationCtx, ttl: number) {

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -590,12 +590,3 @@ async function ensureCleanupCron(ctx: MutationCtx, ttl: number) {
     );
   }
 }
-
-export const queueLength = query({
-  args: {},
-  returns: v.number(),
-  handler: async (ctx) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (ctx.db.query("pendingStart") as any).count();
-  },
-});

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -67,14 +67,14 @@ export const cancel = mutation({
 });
 
 async function getOptions(db: DatabaseReader) {
-  return db.query("pools").unique();
+  return db.query("pool").unique();
 }
 
 async function console(ctx: QueryCtx | ActionCtx) {
   if ("runAction" in ctx) {
     return globalThis.console;
   }
-  const pool = await ctx.db.query("pools").unique();
+  const pool = await ctx.db.query("pool").unique();
   if (!pool) {
     return globalThis.console;
   }
@@ -562,7 +562,7 @@ const CLEANUP_CRON_NAME = "cleanup";
 
 async function ensurePoolExists(
   ctx: MutationCtx,
-  opts: WithoutSystemFields<Doc<"pools">>,
+  opts: WithoutSystemFields<Doc<"pool">>,
   source: "enqueue" | "saveResult" | "mainLoop"
 ) {
   if (opts.maxParallelism > MAX_POSSIBLE_PARALLELISM) {
@@ -571,7 +571,7 @@ async function ensurePoolExists(
   if (opts.maxParallelism < 1) {
     throw new Error("maxParallelism must be >= 1");
   }
-  const pool = await ctx.db.query("pools").unique();
+  const pool = await ctx.db.query("pool").unique();
   if (pool) {
     let update = false;
     for (const key in opts) {
@@ -584,7 +584,7 @@ async function ensurePoolExists(
     }
   }
   if (!pool) {
-    await ctx.db.insert("pools", opts);
+    await ctx.db.insert("pool", opts);
     await startMainLoopHandler(ctx, source);
   }
   await ensureCleanupCron(ctx, opts.statusTtl);

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -44,7 +44,7 @@ To avoid OCCs, we restrict which mutations can read and write from each table:
 
 export default defineSchema({
   // Statically configured, singleton.
-  pools: defineTable({
+  pool: defineTable({
     maxParallelism: v.number(),
     statusTtl: v.number(),
     logLevel,

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -46,7 +46,7 @@ export default defineSchema({
   // Statically configured, singleton.
   pools: defineTable({
     maxParallelism: v.number(),
-    ttl: v.number(),
+    statusTtl: v.number(),
     logLevel,
   }),
 

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -50,8 +50,8 @@ export default defineSchema({
     logLevel,
   }),
 
-  mainLoop: defineTable(
-    v.union(
+  mainLoop: defineTable({
+    state: v.union(
       v.object({ kind: v.literal("running") }),
       v.object({
         kind: v.literal("scheduled"),
@@ -59,8 +59,8 @@ export default defineSchema({
         fn: v.id("_scheduled_functions"),
       }),
       v.object({ kind: v.literal("idle") })
-    )
-  ),
+    ),
+  }),
 
   work: defineTable({
     fnType: v.union(v.literal("action"), v.literal("mutation")),

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -50,8 +50,8 @@ export default defineSchema({
     logLevel,
   }),
 
-  mainLoop: defineTable({
-    state: v.union(
+  mainLoop: defineTable(
+    v.union(
       v.object({ kind: v.literal("running") }),
       v.object({
         kind: v.literal("scheduled"),
@@ -59,8 +59,8 @@ export default defineSchema({
         fn: v.id("_scheduled_functions"),
       }),
       v.object({ kind: v.literal("idle") })
-    ),
-  }),
+    )
+  ),
 
   work: defineTable({
     fnType: v.union(v.literal("action"), v.literal("mutation")),

--- a/src/component/stats.ts
+++ b/src/component/stats.ts
@@ -68,15 +68,22 @@ export const debugCounts = query({
   returns: v.any(),
   handler: async (ctx) => {
     /* eslint-disable @typescript-eslint/no-explicit-any */
+    const inProgressWork = await (
+      ctx.db.query("inProgressWork") as any
+    ).count();
+    const pendingStart = await (ctx.db.query("pendingStart") as any).count();
+    const pendingCompletion = await (
+      ctx.db.query("pendingCompletion") as any
+    ).count();
+    const pendingCancelation = await (
+      ctx.db.query("pendingCancelation") as any
+    ).count();
     return {
-      pendingStart: await (ctx.db.query("pendingStart") as any).count(),
-      inProgressWork: await (ctx.db.query("inProgressWork") as any).count(),
-      pendingCompletion: await (
-        ctx.db.query("pendingCompletion") as any
-      ).count(),
-      pendingCancelation: await (
-        ctx.db.query("pendingCancelation") as any
-      ).count(),
+      pendingStart,
+      inProgressWork,
+      pendingCompletion,
+      pendingCancelation,
+      active: inProgressWork - pendingCompletion - pendingCancelation,
     };
     /* eslint-enable @typescript-eslint/no-explicit-any */
   },

--- a/src/component/stats.ts
+++ b/src/component/stats.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { Doc } from "./_generated/dataModel";
-import { query } from "./_generated/server";
+import { internalQuery } from "./_generated/server";
 
 /**
  * Record stats about work execution. Intended to be queried by Axiom or Datadog.
@@ -50,7 +50,7 @@ export function recordCompleted(
  * Warning: this should not be used from a mutation, as it will cause conflicts.
  * Use this to debug or diagnose your queue length when it's backed up.
  */
-export const queueLength = query({
+export const queueLength = internalQuery({
   args: {},
   returns: v.number(),
   handler: async (ctx) => {
@@ -63,7 +63,7 @@ export const queueLength = query({
  * Warning: this should not be used from a mutation, as it will cause conflicts.
  * Use this while developing to see the state of the queue.
  */
-export const debugCounts = query({
+export const debugCounts = internalQuery({
   args: {},
   returns: v.any(),
   handler: async (ctx) => {


### PR DESCRIPTION
<!-- Describe your PR here. -->

A couple high level concerns:

1. We're fighting retention pretty hard on the pendingCompletion & inProgress. We could get around it by searching from the end of the table, but that's no good when there's a lot of completions. The `mainLoop` is >1s for me right now.
2. It's currently not able to get above the BATCH_SIZE concurrency when there's frequent writes to `pendingCompletion` (which is more likely when `mainLoop` is so slow). It can't do anything until 10 are done, at which point there's the OCC backoff to wait for. then it schedules 10 successfully and completes 10. One solution here is to not limit to BATCH_SIZE on starting jobs, but it can't work faster than consuming 10 per loop (would be less of an issue with shorter loop). For workpools with only ~10 throughput anyways, this looks like waiting for all 10 to finish, if each one finishes within 1s of the previous one. 

https://github.com/user-attachments/assets/7fb8e960-d05a-4d4b-a563-838238422dc3

I have an idea for how to get around the completion retention & contention issues, at the cost of another function call in the main loop cycle, and maybe a function call in the completion handling for mutations too. can discuss over zoom

It's overall in individual commits that can hopefully be reverted if you don't agree. a couple ones in particular:

- pulling the status union into the top level. it doesn't allow us to add more fields that aren't in the union in the future. and there's the `patch` behavior where you have to do replace now, since patching `state` replaces it all, but top-level patching only changes `kind` which might not be valid anymore. maybe top-level unions are an anti-pattern
- using `.count()` for stats

I decided to default to not have everyone who runs this to have a nonstop cron hammering xkcd, even if they never come back to the project :) instead hammering ourselves - maybe a weird pattern to test fetch

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
