### PR TITLE
pendingCompletion shard by generationId

### DIFF
--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -13,7 +13,7 @@ const highPriPool = new Workpool(components.highPriWorkpool, {
   maxParallelism: 20,
   // For tests, disable completed work cleanup.
   statusTtl: Number.POSITIVE_INFINITY,
-  logLevel: "INFO",
+  logLevel: "DEBUG",
 });
 const pool = new Workpool(components.workpool, {
   maxParallelism: 3,
@@ -186,7 +186,7 @@ export const startForegroundWork = internalMutation({
   args: {},
   handler: async (ctx, _args) => {
     await Promise.all(
-      Array.from({ length: 20 }, () =>
+      Array.from({ length: 100 }, () =>
         highPriPool.enqueueAction(ctx, internal.example.foregroundWork, {})
       )
     );

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -2,7 +2,6 @@ import {
   mutation,
   action,
   query,
-  internalMutation,
   internalAction,
 } from "./_generated/server";
 import { api, components, internal } from "./_generated/api";
@@ -182,7 +181,7 @@ export const foregroundWork = internalAction({
   },
 });
 
-export const startForegroundWork = internalMutation({
+export const startForegroundWork = internalAction({
   args: {},
   handler: async (ctx, _args) => {
     await Promise.all(

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -13,7 +13,7 @@ const highPriPool = new Workpool(components.highPriWorkpool, {
   maxParallelism: 20,
   // For tests, disable completed work cleanup.
   statusTtl: Number.POSITIVE_INFINITY,
-  logLevel: "DEBUG",
+  logLevel: "INFO",
 });
 const pool = new Workpool(components.workpool, {
   maxParallelism: 3,

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -1,9 +1,4 @@
-import {
-  mutation,
-  action,
-  query,
-  internalAction,
-} from "./_generated/server";
+import { mutation, action, query, internalAction } from "./_generated/server";
 import { api, components, internal } from "./_generated/api";
 import { Workpool } from "@convex-dev/workpool";
 import { v } from "convex/values";

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -196,7 +196,12 @@ export const mainLoop = internalMutation({
 
     // In case there are more pending completions at higher generation numbers,
     // there's more to do.
-    didSomething ||= (await ctx.db.query("pendingCompletion").first()) !== null;
+    if (!didSomething) {
+      const nextPendingCompletion = await ctx.db.query("pendingCompletion")
+        .withIndex("generation", (q) => q.eq("generation", generationNumber))
+        .first();
+      didSomething = nextPendingCompletion !== null;
+    }
 
     if (!didSomething) {
       console_.time("[mainLoop] inProgressWork check for unclean exits");

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -180,9 +180,10 @@ export const mainLoop = internalMutation({
     );
     console_.timeEnd("[mainLoop] pendingCancelation");
 
-    const nextCompleted = await ctx.db.query("pendingCompletion").first();
-    const nextCanceled = await ctx.db.query("pendingCancelation").first();
-    if (nextCompleted === null && nextCanceled === null) {
+    didSomething ||= (await ctx.db.query("pendingCompletion").first()) !== null;
+    didSomething ||= (await ctx.db.query("pendingCancelation").first()) !== null;
+
+    if (!didSomething) {
       console_.time("[mainLoop] inProgressWork check for unclean exits");
       // If all completions are handled, check everything in inProgressWork.
       // This will find everything that timed out, failed ungracefully, was
@@ -212,7 +213,7 @@ export const mainLoop = internalMutation({
     }
 
     console_.time("[mainLoop] kickMainLoop");
-    if (didSomething || nextCompleted !== null || nextCanceled !== null) {
+    if (didSomething) {
       // There might be more to do.
       await loopFromMainLoop(ctx, 0, haveMoreCompleted);
     } else {

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -180,8 +180,9 @@ export const mainLoop = internalMutation({
     );
     console_.timeEnd("[mainLoop] pendingCancelation");
 
+    // In case there are more pending completions at higher generation numbers,
+    // there's more to do.
     didSomething ||= (await ctx.db.query("pendingCompletion").first()) !== null;
-    didSomething ||= (await ctx.db.query("pendingCancelation").first()) !== null;
 
     if (!didSomething) {
       console_.time("[mainLoop] inProgressWork check for unclean exits");

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -76,8 +76,9 @@ export default defineSchema({
     generation: v.number(),
     completionStatus,
     workId: v.id("work"),
-  }).index("workId", ["workId"])
-  .index("generation", ["generation"]),
+  })
+    .index("workId", ["workId"])
+    .index("generation", ["generation"]),
   pendingCancelation: defineTable({
     workId: v.id("work"),
   }),

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -73,9 +73,11 @@ export default defineSchema({
     workId: v.id("work"),
   }).index("workId", ["workId"]),
   pendingCompletion: defineTable({
+    generation: v.number(),
     completionStatus,
     workId: v.id("work"),
-  }).index("workId", ["workId"]),
+  }).index("workId", ["workId"])
+  .index("generation", ["generation"]),
   pendingCancelation: defineTable({
     workId: v.id("work"),
   }),
@@ -90,4 +92,8 @@ export default defineSchema({
     completionStatus,
     workId: v.id("work"),
   }).index("workId", ["workId"]),
+
+  completionGeneration: defineTable({
+    generation: v.number(),
+  }),
 });


### PR DESCRIPTION
<!-- Describe your PR here. -->

reduce OCC conflicts between completing work and mainLoop with the generation number pattern:

- mainLoop alternates with a quick bumpGeneration mutation
- pending completion writes to the current generation number, while mainLoop reads from previous generation numbers
- saveResult is now always called as a scheduled mutation, to reduce the OCC window with bumpGeneration

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
