### PR TITLE
denormalize inProgressWork count

### DIFF
--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -131,7 +131,8 @@ export const mainLoop = internalMutation({
     // read it all into memory. BUT we don't have to -- we can just read
     // the count from the inProgressCount table.
     const inProgressCount = await ctx.db.query("inProgressCount").unique();
-    const inProgressBefore = (inProgressCount?.count ?? 0) + inProgressCountChange;
+    const inProgressBefore =
+      (inProgressCount?.count ?? 0) + inProgressCountChange;
     console_.debug(`[mainLoop] ${inProgressBefore} in progress`);
     console_.timeEnd("[mainLoop] inProgress count");
 

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -85,6 +85,9 @@ export default defineSchema({
     timeoutMs: v.union(v.number(), v.null()),
     workId: v.id("work"),
   }).index("workId", ["workId"]),
+  inProgressCount: defineTable({
+    count: v.number(),
+  }),
 
   completedWork: defineTable({
     completionStatus,


### PR DESCRIPTION
<!-- Describe your PR here. -->

avoid scanning tombstones on the inProgressWork table by storing a denormalized count, so in most cases we don't need to scan that whole table.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
