### PR TITLE
cursor through pendingStart to avoid walking tombstones

### DIFF
--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -7,7 +7,7 @@ const highPriPool = new Workpool(components.highPriWorkpool, {
   maxParallelism: 20,
   // For tests, disable completed work cleanup.
   statusTtl: Number.POSITIVE_INFINITY,
-  logLevel: "DEBUG",
+  logLevel: "INFO",
 });
 const pool = new Workpool(components.workpool, {
   maxParallelism: 3,

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -7,7 +7,7 @@ const highPriPool = new Workpool(components.highPriWorkpool, {
   maxParallelism: 20,
   // For tests, disable completed work cleanup.
   statusTtl: Number.POSITIVE_INFINITY,
-  logLevel: "INFO",
+  logLevel: "DEBUG",
 });
 const pool = new Workpool(components.workpool, {
   maxParallelism: 3,

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -233,8 +233,9 @@ export const mainLoop = internalMutation({
     // otherwise idle so it doesn't matter if this function takes a while walking
     // tombstones.
     if (!didSomething && pendingStartCursorDoc) {
-      const pendingStartDocs = await ctx.db.query("pendingStart").collect();
-      if (pendingStartDocs.length > 0) {
+      const pendingStartDoc = await ctx.db.query("pendingStart").first();
+      if (pendingStartDoc) {
+        console_.warn(`[mainLoop] missed pendingStart docs; discarding cursor`);
         await ctx.db.delete(pendingStartCursorDoc._id);
         didSomething = true;
       }

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -242,7 +242,10 @@ export const mainLoop = internalMutation({
     // otherwise idle so it doesn't matter if this function takes a while walking
     // tombstones.
     if (!didSomething && pendingStartCursorDoc) {
-      const pendingStartDoc = await ctx.db.query("pendingStart").order("desc").first();
+      const pendingStartDoc = await ctx.db
+        .query("pendingStart")
+        .order("desc")
+        .first();
       if (pendingStartDoc) {
         console_.warn(`[mainLoop] missed pendingStart docs; discarding cursor`);
         await ctx.db.delete(pendingStartCursorDoc._id);

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -100,4 +100,8 @@ export default defineSchema({
   completionGeneration: defineTable({
     generation: v.number(),
   }),
+
+  pendingStartCursor: defineTable({
+    cursor: v.number(),
+  }),
 });


### PR DESCRIPTION
<!-- Describe your PR here. -->

one of the slow parts of mainLoop is when it looks for the next pendingStart documents and potentially skips a bunch of tombstones. To avoid this, we can keep a cursor on the latest `_creationTime` seen. Unfortunately this opens us up to a rare race condition if `_creationTime` is assigned out of order, which we can handle when the mainLoop is about to go idle by checking to see if we missed anything.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
