### PR TITLE
fire onComplete from complete, not loop

### DIFF
--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as complete from "../complete.js";
 import type * as kick from "../kick.js";
 import type * as lib from "../lib.js";
 import type * as logging from "../logging.js";
@@ -31,6 +32,7 @@ import type {
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  complete: typeof complete;
   kick: typeof kick;
   lib: typeof lib;
   logging: typeof logging;

--- a/src/component/complete.ts
+++ b/src/component/complete.ts
@@ -1,0 +1,118 @@
+import { FunctionHandle } from "convex/server";
+import { Infer, v } from "convex/values";
+import { Doc } from "./_generated/dataModel.js";
+import { internalMutation, MutationCtx } from "./_generated/server.js";
+import { kickMainLoop } from "./kick.js";
+import { createLogger, Logger } from "./logging.js";
+import {
+  boundScheduledTime,
+  nextSegment,
+  OnCompleteArgs,
+  runResult,
+  toSegment,
+} from "./shared.js";
+import { recordCompleted } from "./stats.js";
+
+export const completeArgs = v.object({
+  jobs: v.array(
+    v.object({
+      runResult: runResult,
+      workId: v.id("work"),
+    })
+  ),
+});
+export async function completeHandler(
+  ctx: MutationCtx,
+  args: Infer<typeof completeArgs>
+) {
+  const globals = await ctx.db.query("globals").unique();
+  const console = createLogger(globals?.logLevel);
+  await Promise.all(
+    args.jobs.map(async (job) => {
+      const work = await ctx.db.get(job.workId);
+      const maxAttempts = work?.retryBehavior?.maxAttempts;
+      if (!work) {
+        console.warn(`[complete] ${job.workId} is done, but its work is gone`);
+        return;
+      }
+      console.info(recordCompleted(work, job.runResult.kind));
+      if (work.onComplete) {
+        try {
+          const handle = work.onComplete.fnHandle as FunctionHandle<
+            "mutation",
+            OnCompleteArgs,
+            void
+          >;
+          await ctx.runMutation(handle, {
+            workId: work._id,
+            context: work.onComplete.context,
+            result: job.runResult,
+          });
+          console.debug(`[complete] onComplete for ${job.workId} completed`);
+        } catch (e) {
+          console.error(
+            `[complete] error running onComplete for ${job.workId}`,
+            e
+          );
+        }
+      }
+      const pendingCancelations = await ctx.db
+        .query("pendingCancelation")
+        .withIndex("workId", (q) => q.eq("workId", job.workId))
+        .collect();
+      // Ensure there aren't any pending cancelations for this work.
+      for (const pendingCancelation of pendingCancelations) {
+        await ctx.db.delete(pendingCancelation._id);
+      }
+      if (
+        job.runResult.kind === "failed" &&
+        maxAttempts &&
+        pendingCancelations.length === 0 &&
+        work.attempts < maxAttempts
+      ) {
+        await rescheduleJob(ctx, work, console);
+      } else {
+        await ctx.db.delete(job.workId);
+      }
+      await ctx.db.insert("pendingCompletion", {
+        runResult: job.runResult,
+        workId: job.workId,
+        segment: nextSegment(),
+      });
+      await kickMainLoop(ctx, "complete");
+    })
+  );
+}
+
+export const complete = internalMutation({
+  args: completeArgs,
+  handler: completeHandler,
+});
+
+export function withJitter(delay: number) {
+  return delay * (0.5 + Math.random());
+}
+
+async function rescheduleJob(
+  ctx: MutationCtx,
+  work: Doc<"work">,
+  console: Logger
+): Promise<number> {
+  if (!work.retryBehavior) {
+    throw new Error("work has no retryBehavior");
+  }
+  const backoffMs =
+    work.retryBehavior.initialBackoffMs *
+    Math.pow(work.retryBehavior.base, work.attempts - 1);
+  const nextAttempt = withJitter(backoffMs);
+  const startTime = boundScheduledTime(Date.now() + nextAttempt, console);
+  const segment = toSegment(startTime);
+  await ctx.db.patch(work._id, {
+    attempts: work.attempts + 1,
+  });
+  await ctx.db.insert("pendingStart", {
+    workId: work._id,
+    segment,
+  });
+  return nextAttempt;
+}

--- a/src/component/kick.test.ts
+++ b/src/component/kick.test.ts
@@ -176,7 +176,7 @@ describe("kickMainLoop", () => {
       await ctx.db.delete(runStatus._id);
 
       // Kick should recreate runStatus
-      await kickMainLoop(ctx, "recovery");
+      await kickMainLoop(ctx, "complete");
       const newRunStatus = await ctx.db.query("runStatus").unique();
       expect(newRunStatus).not.toBeNull();
       assert(newRunStatus);
@@ -196,7 +196,7 @@ describe("kickMainLoop", () => {
       await ctx.db.delete(globals._id);
 
       // Kick should recreate globals
-      await kickMainLoop(ctx, "recovery");
+      await kickMainLoop(ctx, "complete");
       const newGlobals = await ctx.db.query("globals").unique();
       expect(newGlobals).not.toBeNull();
       assert(newGlobals);
@@ -247,8 +247,7 @@ describe("kickMainLoop", () => {
 
       // Kick from different sources
       await kickMainLoop(ctx, "cancel");
-      await kickMainLoop(ctx, "saveResult");
-      await kickMainLoop(ctx, "recovery");
+      await kickMainLoop(ctx, "complete");
 
       // Config should be preserved
       const globals = await ctx.db.query("globals").unique();

--- a/src/component/kick.ts
+++ b/src/component/kick.ts
@@ -11,7 +11,7 @@ export const DEFAULT_MAX_PARALLELISM = 10;
 
 export async function kickMainLoop(
   ctx: MutationCtx,
-  source: "enqueue" | "cancel" | "saveResult" | "recovery",
+  source: "enqueue" | "cancel" | "complete",
   config?: Partial<Config>
 ): Promise<void> {
   const globals = await getOrUpdateGlobals(ctx, config);
@@ -67,7 +67,7 @@ export const forceKick = internalMutation({
   handler: async (ctx) => {
     const runStatus = await getOrCreateRunStatus(ctx);
     await ctx.db.delete(runStatus._id);
-    await kickMainLoop(ctx, "recovery");
+    await kickMainLoop(ctx, "complete");
   },
 });
 

--- a/src/component/recovery.ts
+++ b/src/component/recovery.ts
@@ -1,9 +1,8 @@
-import { Id } from "./_generated/dataModel.js";
+import { Infer } from "convex/values";
 import { internalMutation } from "./_generated/server.js";
-import { kickMainLoop } from "./kick.js";
+import { completeArgs, completeHandler } from "./complete.js";
 import { createLogger } from "./logging.js";
 import schema from "./schema.js";
-import { RunResult, nextSegment } from "./shared.js";
 
 export const recover = internalMutation({
   args: {
@@ -12,68 +11,62 @@ export const recover = internalMutation({
   handler: async (ctx, { jobs }) => {
     const globals = await ctx.db.query("globals").unique();
     const console = createLogger(globals?.logLevel);
-    const completed: { workId: Id<"work">; runResult: RunResult }[] = [];
-    let didAnything = false;
-    const segment = nextSegment();
-    await Promise.all(
-      jobs.map(async (job) => {
-        const scheduled = await ctx.db.system.get(job.scheduledId);
-        const preamble = `[recovery] Scheduled job ${job.scheduledId} for work ${job.workId}`;
-        if (scheduled === null) {
-          console.warn(`${preamble} not found`);
-          completed.push({
-            workId: job.workId,
-            runResult: { kind: "failed", error: `Scheduled job not found` },
-          });
-          return;
-        }
-        // This will find everything that timed out, failed ungracefully, was
-        // canceled, or succeeded without a return value.
-        switch (scheduled.state.kind) {
-          case "failed": {
-            console.debug(`${preamble} failed and detected in recovery`);
-            const pendingCompletion = await ctx.db
-              .query("pendingCompletion")
-              .withIndex("workId", (q) => q.eq("workId", job.workId))
-              .first();
-            if (pendingCompletion) {
-              console.debug(
-                `${preamble} already in pendingCompletion, not reporting`
-              );
-            } else {
-              await ctx.db.insert("pendingCompletion", {
-                runResult: scheduled.state,
-                workId: job.workId,
-                segment,
-              });
-              didAnything = true;
-            }
-            break;
+    const toComplete: Infer<typeof completeArgs.fields.jobs.element>[] = [];
+    for (let i = 0; i < jobs.length; i++) {
+      const job = jobs[i];
+      const scheduled = await ctx.db.system.get(job.scheduledId);
+      const preamble = `[recovery] Scheduled job ${job.scheduledId} for work ${job.workId}`;
+      if (scheduled === null) {
+        console.warn(`${preamble} not found`);
+        toComplete.push({
+          workId: job.workId,
+          runResult: { kind: "failed", error: `Scheduled job not found` },
+        });
+        continue;
+      }
+      // This will find everything that timed out, failed ungracefully, was
+      // canceled, or succeeded without a return value.
+      switch (scheduled.state.kind) {
+        case "failed": {
+          console.debug(`${preamble} failed and detected in recovery`);
+          const pendingCompletion = await ctx.db
+            .query("pendingCompletion")
+            .withIndex("workId", (q) => q.eq("workId", job.workId))
+            .first();
+          if (pendingCompletion) {
+            console.debug(
+              `${preamble} already in pendingCompletion, not reporting`
+            );
+          } else {
+            toComplete.push({
+              workId: job.workId,
+              runResult: scheduled.state,
+            });
           }
-          case "canceled": {
-            console.debug(`${preamble} was canceled and detected in recovery`);
-            const pendingCancelation = await ctx.db
-              .query("pendingCancelation")
-              .withIndex("workId", (q) => q.eq("workId", job.workId))
-              .first();
-            if (pendingCancelation) {
-              console.debug(
-                `${preamble} already in pendingCancelation, not reporting`
-              );
-            } else {
-              await ctx.db.insert("pendingCancelation", {
-                workId: job.workId,
-                segment,
-              });
-              didAnything = true;
-            }
-            break;
-          }
+          break;
         }
-      })
-    );
-    if (didAnything) {
-      await kickMainLoop(ctx, "recovery");
+        case "canceled": {
+          console.debug(`${preamble} was canceled and detected in recovery`);
+          const pendingCancelation = await ctx.db
+            .query("pendingCancelation")
+            .withIndex("workId", (q) => q.eq("workId", job.workId))
+            .first();
+          if (pendingCancelation) {
+            console.debug(
+              `${preamble} already in pendingCancelation, not reporting`
+            );
+          } else {
+            toComplete.push({
+              workId: job.workId,
+              runResult: { kind: "canceled" },
+            });
+          }
+          break;
+        }
+      }
+    }
+    if (toComplete.length > 0) {
+      await completeHandler(ctx, { jobs: toComplete });
     }
   },
 });


### PR DESCRIPTION
<!-- Describe your PR here. -->

instead of worker -> pendingCompletion -> mainLoop -> `complete` before calling onComplete, 
have the worker (and recovery) call the onComplete and figure out retries while deciding whether to file in pendingCompletion or pendingStart (retry)


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
