### PR TITLE
run onComplete inline always

### DIFF
--- a/src/component/complete.test.ts
+++ b/src/component/complete.test.ts
@@ -238,9 +238,7 @@ describe("complete", () => {
     });
 
     it("should call onComplete handler for successful jobs", async () => {
-      // Create a spy on runMutation
-      // const runMutationSpy = vi.fn();
-      const schedulerSpy = vi.fn();
+      const runMutationSpy = vi.fn();
 
       // Enqueue a work item with onComplete handler
       const workId = await t.mutation(api.lib.enqueue, {
@@ -264,11 +262,7 @@ describe("complete", () => {
         // Create a modified context with a spy on runMutation
         const spyCtx = {
           ...ctx,
-          // runMutation: runMutationSpy,
-          scheduler: {
-            ...ctx.scheduler,
-            runAfter: schedulerSpy,
-          },
+          runMutation: runMutationSpy,
         };
 
         await completeHandler(spyCtx, {
@@ -281,9 +275,8 @@ describe("complete", () => {
           ],
         });
 
-        // Verify onComplete was called with the right arguments
-        expect(schedulerSpy).toHaveBeenCalledWith(
-          0,
+        // Verify onComplete was called transactionally via runMutation
+        expect(runMutationSpy).toHaveBeenCalledWith(
           "testOnComplete",
           expect.objectContaining({
             workId,

--- a/src/component/complete.ts
+++ b/src/component/complete.ts
@@ -117,71 +117,6 @@ export async function completeHandler(
         job.runResult.kind === "failed" &&
         !!maxAttempts &&
         work.attempts < maxAttempts;
-      if (!retry) {
-        let scheduledId = undefined;
-        if (work.onComplete) {
-          try {
-            // Retrieve large context if stored separately
-            let context = work.onComplete.context;
-            if (context === undefined && work.payloadId) {
-              const payload = await ctx.db.get(work.payloadId);
-              if (payload) {
-                context = payload.context;
-              }
-            }
-
-            const handle = work.onComplete.fnHandle as FunctionHandle<
-              "mutation",
-              OnCompleteArgs,
-              void
-            >;
-            const onCompleteArgs = {
-              workId: work._id,
-              context,
-              result: job.runResult,
-            };
-            if (job.runOnCompleteInline) {
-              try {
-                await ctx.runMutation(handle, onCompleteArgs);
-              } catch (e) {
-                console.error(
-                  `[complete] caught error while running onComplete inline for ${job.workId}, scheduling instead: ${e}`,
-                );
-                scheduledId = await ctx.scheduler.runAfter(
-                  0,
-                  handle,
-                  onCompleteArgs,
-                );
-              }
-            } else {
-              scheduledId = await ctx.scheduler.runAfter(
-                0,
-                handle,
-                onCompleteArgs,
-              );
-              console.debug(
-                `[complete] onComplete for ${job.workId} scheduled`,
-              );
-            }
-          } catch (e) {
-            console.error(
-              `[complete] error running onComplete for ${job.workId}`,
-              e,
-            );
-            // TODO: store failures in a table for later debugging
-          }
-        }
-        recordCompleted(console, work, job.runResult.kind, scheduledId);
-
-        // Clean up any large data that was stored separately.
-        // TODO: consider async deletion in the future to avoid bandwidth limits.
-        if (work.payloadId) {
-          await ctx.db.delete(work.payloadId);
-        }
-
-        // This is the terminating state for work.
-        await ctx.db.delete(job.workId);
-      }
       if (job.runResult.kind !== "canceled") {
         pendingCompletions.push({
           runResult: stripResult(job.runResult),
@@ -189,6 +124,53 @@ export async function completeHandler(
           retry,
         });
       }
+      if (retry) {
+        return;
+      }
+      if (work.onComplete) {
+        // Retrieve large context if stored separately
+        let context = work.onComplete.context;
+        if (context === undefined && work.payloadId) {
+          const payload = await ctx.db.get(work.payloadId);
+          if (payload) {
+            context = payload.context;
+          }
+        }
+
+        const handle = work.onComplete.fnHandle as FunctionHandle<
+          "mutation",
+          OnCompleteArgs,
+          void
+        >;
+        const onCompleteArgs = {
+          workId: work._id,
+          context,
+          result: job.runResult,
+        };
+        try {
+          await ctx.runMutation(handle, onCompleteArgs);
+        } catch (e) {
+          console.error(
+            `[complete] error running onComplete for ${job.workId}`,
+            e,
+          );
+          await ctx.db.insert("failedOnComplete", {
+            workId: job.workId,
+            context,
+            runResult: stripResult(job.runResult),
+          });
+        }
+      }
+      recordCompleted(console, work, job.runResult.kind);
+
+      // Clean up any large data that was stored separately.
+      // TODO: consider async deletion in the future to avoid bandwidth limits.
+      if (work.payloadId) {
+        await ctx.db.delete(work.payloadId);
+      }
+
+      // This is the terminating state for work.
+      await ctx.db.delete(job.workId);
     }),
   );
   if (pendingCompletions.length > 0) {

--- a/src/component/loop.ts
+++ b/src/component/loop.ts
@@ -403,7 +403,7 @@ async function handleCompletions(
         const retried = await rescheduleJob(ctx, work, console);
         if (retried) {
           state.report.retries++;
-          recordCompleted(console, work, "retrying", undefined);
+          recordCompleted(console, work, "retrying");
         } else {
           // We don't retry if it's been canceled in the mean time.
           state.report.canceled++;

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -104,4 +104,10 @@ export default defineSchema({
     args: v.optional(v.record(v.string(), v.any())),
     context: v.optional(v.any()),
   }),
+
+  failedOnComplete: defineTable({
+    workId: v.id("work"),
+    context: v.optional(v.any()),
+    runResult: vResult,
+  }),
 });

--- a/src/component/stats.ts
+++ b/src/component/stats.ts
@@ -54,13 +54,11 @@ export function recordCompleted(
   console: Logger,
   work: Doc<"work">,
   status: "success" | "failed" | "canceled" | "retrying",
-  onCompleteScheduledFunctionId: Id<"_scheduled_functions"> | undefined,
 ) {
   console.event("completed", {
     workId: work._id,
     fnName: work.fnName,
     completedAt: Date.now(),
-    onCompleteScheduledFunctionId,
     attempts: work.attempts,
     status,
   });

--- a/src/component/worker.ts
+++ b/src/component/worker.ts
@@ -36,20 +36,18 @@ export const runMutationWrapper = internalMutation({
       fnArgs = payload.args;
     }
 
+    let runResult: RunResult = { kind: "failed", error: "unknown" };
     try {
       const returnValue = await (args.fnType === "query"
         ? ctx.runQuery(args.fnHandle as FunctionHandle<"query">, fnArgs)
         : ctx.runMutation(args.fnHandle as FunctionHandle<"mutation">, fnArgs));
       // NOTE: we could run the `saveResult` handler here, or call `ctx.runMutation`,
       // but we want the mutation to be a separate transaction to reduce the window for OCCs.
-      await ctx.scheduler.runAfter(0, internal.complete.complete, {
-        jobs: [
-          { workId, runResult: { kind: "success", returnValue }, attempt },
-        ],
-      });
+      runResult = { kind: "success", returnValue };
     } catch (e: unknown) {
       console.error(e);
-      const runResult = { kind: "failed" as const, error: formatError(e) };
+      runResult = { kind: "failed" as const, error: formatError(e) };
+    } finally {
       await ctx.scheduler.runAfter(0, internal.complete.complete, {
         jobs: [{ workId, runResult, attempt }],
       });

--- a/src/component/worker.ts
+++ b/src/component/worker.ts
@@ -92,17 +92,17 @@ export const runActionWrapper = internalAction({
       // and `ctx.scheduler.runAfter` won't OCC.
       const runResult: RunResult = { kind: "success", returnValue };
       try {
-        // Attempt to run complete inline and onComplete inline
+        // Attempt to run complete inline
         await ctx.runMutation(internal.complete.complete, {
-          jobs: [{ workId, runResult, attempt, runOnCompleteInline: true }],
+          jobs: [{ workId, runResult, attempt }],
         });
-        console.info("[runActionWrapper] onComplete succeeded");
+        console.debug("[runActionWrapper] completed inline");
         return;
       } catch (e) {
         console.error(
           `[runActionWrapper] caught error while attempting to run complete inline, scheduling instead: ${e}`,
         );
-        // Fall through and schedule complete instead (without running onComplete inline)
+        // Fall through and schedule complete instead
       }
       await ctx.scheduler.runAfter(0, internal.complete.complete, {
         jobs: [{ workId, runResult, attempt }],


### PR DESCRIPTION
Instead of doing inline/inline -> schedule/schedule, let's do inline/inline -> schedule/inline, always running the onComplete handler inline in complete.ts so that the scheduler doesn't balloon with OCC-ing / retrying onComplete handlers while the workpool charges ahead. 

Also write failed onComplete handlers for investigation / recovery purposes - though it'll be missing the full return value for now.

For un-catchable errors (e.g. the onComplete reads too much data) I think it would still wedge the workpool - but that's pre-existing and a bit orthogonal here