### PR TITLE
kick on completion

### DIFF
--- a/src/component/complete.ts
+++ b/src/component/complete.ts
@@ -197,7 +197,10 @@ export async function completeHandler(
     }),
   );
   if (pendingCompletions.length > 0) {
-    await kickMainLoop(ctx, "complete");
+    const source = pendingCompletions.some((c) => c.retry)
+      ? "retry"
+      : "complete";
+    await kickMainLoop(ctx, source);
     const segment = getCurrentSegment();
     await Promise.all(
       pendingCompletions.map((completion) =>

--- a/src/component/kick.test.ts
+++ b/src/component/kick.test.ts
@@ -106,6 +106,41 @@ describe("kickMainLoop", () => {
     });
   });
 
+  test("kicks on retry even when not saturated (#198)", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await kickMainLoop(ctx, "enqueue");
+      const runStatus = await ctx.db.query("runStatus").unique();
+      assert(runStatus);
+
+      // Simulate the loop having gone to sleep with one job running.
+      // saturated=false because 1 < maxParallelism.
+      const farFutureSegment = toSegment(Date.now() + 60_000);
+      const scheduledId = await ctx.scheduler.runAfter(
+        60_000,
+        internal.loop.main,
+        { generation: 0n, segment: farFutureSegment },
+      );
+      await ctx.db.patch("runStatus", runStatus._id, {
+        state: {
+          kind: "scheduled",
+          scheduledId,
+          saturated: false,
+          generation: 0n,
+          segment: farFutureSegment,
+        },
+      });
+
+      // A retry should bring the loop forward so the new pendingStart is
+      // processed promptly, not 60s from now.
+      await kickMainLoop(ctx, "retry");
+
+      const after = await ctx.db.query("runStatus").unique();
+      assert(after);
+      expect(after.state.kind).toBe("running");
+    });
+  });
+
   test("does not kick when scheduled and saturated", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {

--- a/src/component/kick.ts
+++ b/src/component/kick.ts
@@ -18,7 +18,7 @@ import {
  */
 export async function kickMainLoop(
   ctx: MutationCtx,
-  source: "enqueue" | "cancel" | "complete" | "kick",
+  source: "enqueue" | "cancel" | "complete" | "retry" | "kick",
   config?: Config,
 ): Promise<void> {
   const globals = config ?? (await getOrUpdateGlobals(ctx, config));
@@ -41,6 +41,9 @@ export async function kickMainLoop(
       return;
     }
     if (source === "complete" && !runStatus.state.saturated) {
+      // A pure completion doesn't create new work to start, so the loop's
+      // existing wake-up is fine. Retries (source "retry") do create new
+      // pendingStart work and fall through to kick the loop promptly.
       console.debug(
         `[${source}] main is not saturated, so kicking for completion isn't necessary`,
       );


### PR DESCRIPTION
When a task is completing and has retries and the workpool isn't running, run it.

Fixes #198