### PR TITLE
Order pending work by commit and snapshot timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,31 @@
   can appear behind a cursor the main loop has already read past. That removes
   the 15-second cursor rewind buffer and the once-a-minute full rescan that
   0.4.7 added to cope with out-of-order inserts — the loop now reads only rows
-  it hasn't seen. On a 5000-task saturation benchmark (parallelism 200, 20ms
-  tasks) this ran ~16% faster — 121 → 144 tasks/s, with p99 latency down from
-  ~32s to ~25s.
-- The `segment` fields keep their name and index, but now hold nanoseconds
-  rather than 100ms buckets. Work scheduled to start later stores its start time
-  there directly, which sorts after everything already committed, so one index
-  covers both ready and scheduled work.
+  it hasn't seen, which improves throughput and tail latency for saturated
+  pools.
+- The `segment` fields keep their name, but now hold nanoseconds rather than
+  100ms buckets. Work scheduled to start later stores its start time there
+  directly, which sorts after everything already committed, so ready and
+  scheduled work share an ordering.
+- Work scheduled less than five minutes out can't safely store its start time at
+  enqueue, so it's held at its commit position until the loop moves it. A
+  `hasRunAt` marker puts those entries in their own lane of the `pendingStart`
+  index, moved along at a full batch per iteration in parallel with starting
+  ready work — so a bulk enqueue of near-future work never delays work that's
+  ready now.
 - Upgrading in place is safe, including for work that hasn't come due yet. A
   `pendingStart` an older version wrote holds a 100ms bucket — eight orders of
   magnitude below a nanosecond timestamp — so the loop recognizes it, reads the
   bucket back as the time the work should start, and either starts it or
-  rewrites it as a timestamp and leaves it alone until then. Queued completions
-  and cancelations sort first and drain immediately, which is what they want.
-- Requires `convex` 1.43 or later. Downgrading is not supported: an older
-  version would read a nanosecond timestamp as a 100ms bucket far in the future
-  and never start the work.
+  rewrites it as a timestamp and leaves it alone until then. This is a one-time
+  re-ordering of every queued entry, 64 per loop iteration, so right after the
+  push a large backlog of scheduled work adds processing overhead and can
+  briefly delay work that's ready now. Queued completions and cancelations sort
+  first and drain immediately, which is what they want.
+- This change is not backwards compatible. It requires `convex` 1.43 or later,
+  and downgrading a workpool that has run this version is not supported: an
+  older version would read a nanosecond timestamp as a 100ms bucket far in the
+  future and never start the work.
 
 ## 0.4.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+- Orders the pending-work queues by commit timestamp (`v.commitTs()`, Convex ≥
+  1.43). A commit timestamp is assigned when the transaction commits, so nothing
+  can appear behind a cursor the main loop has already read past. That removes
+  the 15-second cursor rewind buffer and the once-a-minute full rescan that
+  0.4.7 added to cope with out-of-order inserts — the loop now reads only rows
+  it hasn't seen. On a 5000-task saturation benchmark (parallelism 200, 20ms
+  tasks) this ran ~16% faster — 121 → 144 tasks/s, with p99 latency down from
+  ~32s to ~25s.
+- The `segment` fields keep their name and index, but now hold nanoseconds
+  rather than 100ms buckets. Work scheduled to start later stores its start time
+  there directly, which sorts after everything already committed, so one index
+  covers both ready and scheduled work. Entries an older version wrote have much
+  smaller values, so they sort first and get processed promptly on upgrade.
+- Requires `convex` 1.43 or later.
+
 ## 0.4.9
 
 - Runs actions and queries in batches of up to 32 from a single scheduled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,16 @@
 - The `segment` fields keep their name and index, but now hold nanoseconds
   rather than 100ms buckets. Work scheduled to start later stores its start time
   there directly, which sorts after everything already committed, so one index
-  covers both ready and scheduled work. Entries an older version wrote have much
-  smaller values, so they sort first and get processed promptly on upgrade.
-- Requires `convex` 1.43 or later.
+  covers both ready and scheduled work.
+- Upgrading in place is safe, including for work that hasn't come due yet. A
+  `pendingStart` an older version wrote holds a 100ms bucket — eight orders of
+  magnitude below a nanosecond timestamp — so the loop recognizes it, reads the
+  bucket back as the time the work should start, and either starts it or
+  rewrites it as a timestamp and leaves it alone until then. Queued completions
+  and cancelations sort first and drain immediately, which is what they want.
+- Requires `convex` 1.43 or later. Downgrading is not supported: an older
+  version would read a nanosecond timestamp as a 100ms bucket far in the future
+  and never start the work.
 
 ## 0.4.9
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ can learn about [here](https://docs.convex.dev/get-started).
 Run `npm create convex` or follow any of the
 [quickstarts](https://docs.convex.dev/home) to set one up.
 
+Workpool orders its internal queues by
+[commit timestamp](https://docs.convex.dev/database/advanced/commit-timestamp),
+so it needs `convex` 1.43 or later.
+
 ### Install the component
 
 See [`example/`](./example/convex/) for a working demo.

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -24,6 +24,7 @@ import type * as test_scenarios_noisyNeighbor from "../test/scenarios/noisyNeigh
 import type * as test_scenarios_overhead from "../test/scenarios/overhead.js";
 import type * as test_scenarios_sustained from "../test/scenarios/sustained.js";
 import type * as test_scenarios_throughput from "../test/scenarios/throughput.js";
+import type * as test_scheduling from "../test/scheduling.js";
 import type * as test_work from "../test/work.js";
 
 import type {
@@ -49,6 +50,7 @@ declare const fullApi: ApiFromModules<{
   "test/scenarios/overhead": typeof test_scenarios_overhead;
   "test/scenarios/sustained": typeof test_scenarios_sustained;
   "test/scenarios/throughput": typeof test_scenarios_throughput;
+  "test/scheduling": typeof test_scheduling;
   "test/work": typeof test_work;
 }>;
 

--- a/example/convex/schema.ts
+++ b/example/convex/schema.ts
@@ -38,4 +38,11 @@ export default defineSchema({
     name: v.string(),
     value: v.number(),
   }).index("name", ["name"]),
+  // When each probe in test/scheduling.ts ran, to check delayed and retried
+  // work against a real deployment.
+  schedulingProbes: defineTable({
+    label: v.string(),
+    at: v.number(),
+    attempt: v.optional(v.number()),
+  }),
 });

--- a/example/convex/test/scheduling.ts
+++ b/example/convex/test/scheduling.ts
@@ -1,0 +1,147 @@
+import { v } from "convex/values";
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+} from "../_generated/server";
+import { components, internal } from "../_generated/api";
+import { Workpool } from "@convex-dev/workpool";
+
+/**
+ * End-to-end checks for the two paths the throughput scenarios never touch:
+ * work scheduled for later, and work that retries. Both put a wall-clock time
+ * into the queue's commit-timestamp-ordered field instead of the placeholder,
+ * so they're worth exercising against a real deployment and not just
+ * convex-test.
+ *
+ * Run:
+ *   npx convex run test/scheduling:default
+ *   npx convex run test/scheduling:default '{"delayMs":400000}'  # past the
+ *                                          # safe-future threshold
+ */
+const pool = new Workpool(components.testWorkpool, { maxParallelism: 10 });
+
+const vProbe = v.object({
+  label: v.string(),
+  at: v.number(),
+  attempt: v.optional(v.number()),
+});
+
+export const record = internalMutation({
+  args: { label: v.string(), attempt: v.optional(v.number()) },
+  returns: v.null(),
+  handler: async (ctx, { label, attempt }) => {
+    await ctx.db.insert("schedulingProbes", { label, at: Date.now(), attempt });
+    return null;
+  },
+});
+
+export const probes = internalQuery({
+  args: {},
+  returns: v.array(vProbe),
+  handler: async (ctx) => {
+    const docs = await ctx.db.query("schedulingProbes").collect();
+    return docs
+      .map(({ label, at, attempt }) => ({ label, at, attempt }))
+      .sort((a, b) => a.at - b.at);
+  },
+});
+
+export const reset = internalMutation({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    for (const doc of await ctx.db.query("schedulingProbes").collect()) {
+      await ctx.db.delete("schedulingProbes", doc._id);
+    }
+    return null;
+  },
+});
+
+/** Fails its first two attempts so the retry backoff path runs. */
+export const failTwice = internalAction({
+  args: { label: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { label }) => {
+    const seen = (
+      await ctx.runQuery(internal.test.scheduling.probes, {})
+    ).filter((p) => p.label === label).length;
+    await ctx.runMutation(internal.test.scheduling.record, {
+      label,
+      attempt: seen + 1,
+    });
+    if (seen < 2) throw new Error(`attempt ${seen + 1} fails on purpose`);
+    return null;
+  },
+});
+
+export const enqueueBoth = internalMutation({
+  args: { delayMs: v.number() },
+  returns: v.null(),
+  handler: async (ctx, { delayMs }) => {
+    await pool.enqueueMutation(
+      ctx,
+      internal.test.scheduling.record,
+      { label: "delayed" },
+      { runAfter: delayMs },
+    );
+    await pool.enqueueAction(
+      ctx,
+      internal.test.scheduling.failTwice,
+      { label: "retry" },
+      { retry: { maxAttempts: 4, initialBackoffMs: 500, base: 2 } },
+    );
+    return null;
+  },
+});
+
+export default internalAction({
+  args: { delayMs: v.optional(v.number()) },
+  handler: async (ctx, { delayMs = 8_000 }) => {
+    await ctx.runMutation(internal.test.scheduling.reset, {});
+
+    const enqueuedAt = Date.now();
+    await ctx.runMutation(internal.test.scheduling.enqueueBoth, { delayMs });
+
+    const deadline = Date.now() + delayMs + 60_000;
+    // Keep the number of polls bounded — a long delay at a fixed short interval
+    // runs past an action's limit on how many functions it may call.
+    const pollMs = Math.max(250, Math.round(delayMs / 100));
+    let probes: { label: string; at: number; attempt?: number }[] = [];
+    let ranEarly = false;
+    while (Date.now() < deadline) {
+      probes = await ctx.runQuery(internal.test.scheduling.probes, {});
+      const delayed = probes.find((p) => p.label === "delayed");
+      if (delayed && delayed.at < enqueuedAt + delayMs) ranEarly = true;
+      const retriesDone = probes.filter((p) => p.label === "retry").length >= 3;
+      if (delayed && retriesDone) break;
+      await new Promise((r) => setTimeout(r, pollMs));
+    }
+
+    const delayed = probes.find((p) => p.label === "delayed");
+    const retries = probes.filter((p) => p.label === "retry");
+    const lateByMs = delayed ? delayed.at - (enqueuedAt + delayMs) : undefined;
+
+    console.log("=== scheduling results ===");
+    console.log(
+      delayed
+        ? `delayed (runAfter ${delayMs}ms): ran ${lateByMs}ms after its runAt` +
+            (ranEarly ? " — RAN EARLY" : "")
+        : `delayed (runAfter ${delayMs}ms): NEVER RAN`,
+    );
+    console.log(
+      `retry: ${retries.length} attempts, gaps ${
+        retries
+          .slice(1)
+          .map((p, i) => p.at - retries[i].at)
+          .join("/") || "n/a"
+      }ms`,
+    );
+    return {
+      delayedRan: !!delayed,
+      delayedRanEarly: ranEarly,
+      delayedLateByMs: lateByMs,
+      retryAttempts: retries.length,
+    };
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@vitejs/plugin-react": "5.1.3",
         "@vitest/coverage-v8": "4.1.8",
         "chokidar-cli": "3.0.0",
-        "convex": "1.41.0",
+        "convex": "1.43.0",
         "convex-helpers": "0.1.111",
         "convex-test": "0.0.53",
         "eslint": "10.0.2",
@@ -553,16 +553,16 @@
       }
     },
     "node_modules/@convex-dev/eslint-plugin/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@convex-dev/eslint-plugin/node_modules/minimatch": {
@@ -1127,16 +1127,16 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -2454,16 +2454,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -2843,9 +2843,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3063,14 +3063,14 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.41.0.tgz",
-      "integrity": "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.43.0.tgz",
+      "integrity": "sha512-huZWEUZQYxIRG104o22ZI99HkviSEVltwezZRDi+pQDPrQbc5EoCPa4Y7pJDqUBQw9dc/iEEXj2/rLZg1j7Dww==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
-        "ws": "8.20.1"
+        "ws": "8.21.0"
       },
       "bin": {
         "convex": "bin/main.js"
@@ -3583,16 +3583,16 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint/node_modules/espree": {
@@ -4120,9 +4120,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -4338,9 +4338,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4557,9 +4557,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -4577,7 +4577,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5225,9 +5225,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5637,9 +5637,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "chokidar-cli": "3.0.0",
         "convex": "1.43.0",
         "convex-helpers": "0.1.111",
-        "convex-test": "0.0.55-alpha.0",
+        "convex-test": "0.0.55",
         "eslint": "10.0.2",
         "eslint-plugin-react-hooks": "7.1.0-canary-3f0b9e61-20260317",
         "eslint-plugin-react-refresh": "0.5.0",
@@ -3139,9 +3139,9 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.55-alpha.0",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.55-alpha.0.tgz",
-      "integrity": "sha512-zg9LM91HZYpiH+uinx8uUImttRwtHKCRYlMfY6fwvWYQcB6gaP4KhLqvy2nnmt7z3ls8+DLD3YQ2que1z5QSPg==",
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.55.tgz",
+      "integrity": "sha512-ablJ6vR3WUpyTaYrrRQf8yxInGrhHyqBEQsCFzloda3G0MDEu2RMKNGUkvlBXYWPiiEP0UIKPS7gZuLbqGnvQw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "chokidar-cli": "3.0.0",
         "convex": "1.43.0",
         "convex-helpers": "0.1.111",
-        "convex-test": "0.0.53",
+        "convex-test": "0.0.55-alpha.0",
         "eslint": "10.0.2",
         "eslint-plugin-react-hooks": "7.1.0-canary-3f0b9e61-20260317",
         "eslint-plugin-react-refresh": "0.5.0",
@@ -42,7 +42,7 @@
         "vitest": "4.1.8"
       },
       "peerDependencies": {
-        "convex": "^1.36.1",
+        "convex": "^1.43.0",
         "convex-helpers": "^0.1.94"
       }
     },
@@ -3139,13 +3139,13 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.53.tgz",
-      "integrity": "sha512-bouZQTnTvZi8IHljHL++yClj1vcV+/9ZxEcd8JZz7RDxOfPkRKrkMgkk/xlX4M1EAiwcEJPNiQE7VJFvDM3lCQ==",
+      "version": "0.0.55-alpha.0",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.55-alpha.0.tgz",
+      "integrity": "sha512-zg9LM91HZYpiH+uinx8uUImttRwtHKCRYlMfY6fwvWYQcB6gaP4KhLqvy2nnmt7z3ls8+DLD3YQ2que1z5QSPg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "convex": "^1.32.0"
+        "convex": "^1.43.0"
       }
     },
     "node_modules/cross-spawn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@convex-dev/eslint-plugin": "^2.0.0",
         "@convex-dev/static-hosting": "^0.2.0",
-        "@convex-dev/workpool-old": "npm:@convex-dev/workpool@0.4.7",
+        "@convex-dev/workpool-old": "npm:@convex-dev/workpool@0.4.9",
         "@edge-runtime/vm": "5.0.0",
         "@eslint/eslintrc": "3.3.3",
         "@eslint/js": "10.0.1",
@@ -610,13 +610,16 @@
     },
     "node_modules/@convex-dev/workpool-old": {
       "name": "@convex-dev/workpool",
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.4.7.tgz",
-      "integrity": "sha512-4O3VKcJXqYZ9icDgKdVPxjDGUAFK3oG0hbUwLcyYMYgsvVKlZDhvZRmczqSBZHLyrCGPpf925byh0dBigCfAGA==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.4.9.tgz",
+      "integrity": "sha512-2EauCO+fXqhBE0qN3aC2G/CA8Udc1nDiSha2uwdJi5SaElz6HmuM3Rv60AeQ3snMZ8PdHugKKlVeEFvAhSaokQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@convex-dev/batch-worker": "^0.2.0"
+      },
       "peerDependencies": {
-        "convex": "^1.31.7",
+        "convex": "^1.36.1",
         "convex-helpers": "^0.1.94"
       }
     },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@convex-dev/eslint-plugin": "^2.0.0",
     "@convex-dev/static-hosting": "^0.2.0",
-    "@convex-dev/workpool-old": "npm:@convex-dev/workpool@0.4.7",
+    "@convex-dev/workpool-old": "npm:@convex-dev/workpool@0.4.9",
     "@edge-runtime/vm": "5.0.0",
     "@eslint/eslintrc": "3.3.3",
     "@eslint/js": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@vitejs/plugin-react": "5.1.3",
     "@vitest/coverage-v8": "4.1.8",
     "chokidar-cli": "3.0.0",
-    "convex": "1.41.0",
+    "convex": "1.43.0",
     "convex-helpers": "0.1.111",
     "convex-test": "0.0.53",
     "eslint": "10.0.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     }
   },
   "peerDependencies": {
-    "convex": "^1.36.1",
+    "convex": "^1.43.0",
     "convex-helpers": "^0.1.94"
   },
   "devDependencies": {
@@ -85,7 +85,7 @@
     "chokidar-cli": "3.0.0",
     "convex": "1.43.0",
     "convex-helpers": "0.1.111",
-    "convex-test": "0.0.53",
+    "convex-test": "0.0.55-alpha.0",
     "eslint": "10.0.2",
     "eslint-plugin-react-hooks": "7.1.0-canary-3f0b9e61-20260317",
     "eslint-plugin-react-refresh": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "chokidar-cli": "3.0.0",
     "convex": "1.43.0",
     "convex-helpers": "0.1.111",
-    "convex-test": "0.0.55-alpha.0",
+    "convex-test": "0.0.55",
     "eslint": "10.0.2",
     "eslint-plugin-react-hooks": "7.1.0-canary-3f0b9e61-20260317",
     "eslint-plugin-react-refresh": "0.5.0",

--- a/src/component/complete.test.ts
+++ b/src/component/complete.test.ts
@@ -80,7 +80,11 @@ describe("complete", () => {
       );
       await ctx.db.insert("internalState", {
         generation: 0n,
-        segmentCursors: { incoming: 0n, completion: 0n, cancelation: 0n },
+        segmentCursors: {
+          incoming: 0n,
+          completion: 0n,
+          cancelation: 0n,
+        },
         lastRecovery: 0n,
         report: {
           completed: 0,

--- a/src/component/complete.ts
+++ b/src/component/complete.ts
@@ -5,12 +5,7 @@ import { internal } from "./_generated/api.js";
 import { internalMutation, type MutationCtx } from "./_generated/server.js";
 import { kickMainLoop } from "./kick.js";
 import { createLogger } from "./logging.js";
-import {
-  getCurrentSegment,
-  type OnCompleteArgs,
-  type RunResult,
-  vResult,
-} from "./shared.js";
+import { type OnCompleteArgs, type RunResult, vResult } from "./shared.js";
 import { recordCompleted } from "./stats.js";
 import { assert } from "convex-helpers";
 
@@ -211,12 +206,11 @@ export async function completeHandler(
         ? "retry"
         : "complete",
     );
-    const segment = getCurrentSegment();
     await Promise.all(
       pendingCompletions.map((completion) =>
         ctx.db.insert("pendingCompletion", {
           ...completion,
-          segment,
+          segment: ctx.db.vars.commitTs,
         }),
       ),
     );

--- a/src/component/kick.test.ts
+++ b/src/component/kick.test.ts
@@ -34,7 +34,11 @@ describe("kickMainLoop", () => {
       );
       await ctx.db.insert("internalState", {
         generation: 0n,
-        segmentCursors: { incoming: 0n, completion: 0n, cancelation: 0n },
+        segmentCursors: {
+          incoming: 0n,
+          completion: 0n,
+          cancelation: 0n,
+        },
         lastRecovery: 0n,
         report: {
           completed: 0,

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -19,12 +19,11 @@ import {
   boundScheduledTime,
   vConfig,
   fnType,
-  getCurrentSegment,
-  max,
   vOnCompleteFnContext,
   retryBehavior,
+  SAFE_FUTURE_MS,
   status as statusValidator,
-  toSegment,
+  toTimestamp,
 } from "./shared.js";
 import { recordEnqueued } from "./stats.js";
 import { getOrUpdateGlobals } from "./config.js";
@@ -112,9 +111,17 @@ async function enqueueHandler(
   // Store the work item
   const workId = await ctx.db.insert("work", workItem);
 
+  // Ready now: order it by this transaction's commit timestamp. Far enough out
+  // that no commit latency could put it behind the loop's cursor: order it by
+  // its start time directly. In between: order it by the commit timestamp so
+  // it can't be lost, and let the loop move it forward once it sees the `runAt`
+  // (see `promoteScheduled`) — one extra write, only for near-future work.
+  const delayMs = runAt - Date.now();
   await ctx.db.insert("pendingStart", {
     workId,
-    segment: max(toSegment(runAt), getCurrentSegment()),
+    segment:
+      delayMs > SAFE_FUTURE_MS ? toTimestamp(runAt) : ctx.db.vars.commitTs,
+    ...(delayMs > 0 ? { runAt } : {}),
   });
   recordEnqueued(console, { workId, fnName: workArgs.fnName, runAt });
   return workId;
@@ -146,7 +153,7 @@ export const cancel = mutation({
       await kickMainLoop(ctx, "cancel");
       await ctx.db.insert("pendingCancelation", {
         workId: id,
-        segment: getCurrentSegment(),
+        segment: ctx.db.vars.commitTs,
       });
     }
   },
@@ -176,13 +183,12 @@ export const cancelAll = mutation({
     if (shouldCancel.some((c) => c)) {
       await kickMainLoop(ctx, "cancel");
     }
-    const segment = getCurrentSegment();
     await Promise.all(
       pageOfWork.map(({ _id }, index) => {
         if (shouldCancel[index]) {
           return ctx.db.insert("pendingCancelation", {
             workId: _id,
-            segment,
+            segment: ctx.db.vars.commitTs,
           });
         }
       }),

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -56,7 +56,8 @@ export const enqueue = mutation({
     return await enqueueHandler(ctx, console, itemArgs);
   },
 });
-async function enqueueHandler(
+/** Exported for tests, so they enqueue exactly what the public API writes. */
+export async function enqueueHandler(
   ctx: MutationCtx,
   console: Logger,
   { runAt, ...workArgs }: ObjectType<typeof itemArgs>,
@@ -116,12 +117,15 @@ async function enqueueHandler(
   // its start time directly. In between: order it by the commit timestamp so
   // it can't be lost, and let the loop move it forward once it sees the `runAt`
   // (see `promoteScheduled`) — one extra write, only for near-future work.
+  // `hasRunAt` puts that last case in its own index lane, so entries waiting
+  // to be moved never sit in front of ready work.
   const delayMs = runAt - Date.now();
   await ctx.db.insert("pendingStart", {
     workId,
     segment:
       delayMs > SAFE_FUTURE_MS ? toTimestamp(runAt) : ctx.db.vars.commitTs,
     ...(delayMs > 0 ? { runAt } : {}),
+    ...(delayMs > 0 && delayMs <= SAFE_FUTURE_MS ? { hasRunAt: true } : {}),
   });
   recordEnqueued(console, { workId, fnName: workArgs.fnName, runAt });
   return workId;

--- a/src/component/loop.test.ts
+++ b/src/component/loop.test.ts
@@ -15,8 +15,8 @@ import { setupTest } from "./setup.test.js";
 import {
   DEFAULT_MAX_PARALLELISM,
   fromSegment,
-  getCurrentSegment,
-  toSegment,
+  SAFE_FUTURE_MS,
+  toTimestamp,
   WORKER_NAME,
 } from "./shared.js";
 
@@ -76,7 +76,11 @@ describe("loop", () => {
     await t.run(async (ctx) => {
       await ctx.db.insert("internalState", {
         generation: 0n,
-        segmentCursors: { incoming: 0n, completion: 0n, cancelation: 0n },
+        segmentCursors: {
+          incoming: 0n,
+          completion: 0n,
+          cancelation: 0n,
+        },
         lastRecovery: 0n,
         report: {
           completed: 0,
@@ -92,12 +96,15 @@ describe("loop", () => {
   }
 
   /**
-   * Insert a work doc + pendingStart at the given segment (default: now).
+   * Insert a work doc + pendingStart the way `enqueue` does. `runAt` holds the
+   * work until then; the default runs it as soon as the loop sees it. `segment`
+   * pins the ordering value, e.g. to give several entries the same one the way
+   * a single batch enqueue does.
    * Bypasses the public enqueue API to keep tests focused on the loop.
    */
   async function enqueueWork(
     overrides: Partial<WithoutSystemFields<Doc<"work">>> = {},
-    segment = getCurrentSegment(),
+    { runAt, segment }: { runAt?: number; segment?: bigint } = {},
   ): Promise<Id<"work">> {
     return t.run(async (ctx) => {
       const workId = await ctx.db.insert("work", {
@@ -108,7 +115,16 @@ describe("loop", () => {
         attempts: 0,
         ...overrides,
       });
-      await ctx.db.insert("pendingStart", { workId, segment });
+      const delayMs = (runAt ?? 0) - Date.now();
+      await ctx.db.insert("pendingStart", {
+        workId,
+        segment:
+          segment ??
+          (delayMs > SAFE_FUTURE_MS
+            ? toTimestamp(runAt!)
+            : ctx.db.vars.commitTs),
+        ...(delayMs > 0 ? { runAt } : {}),
+      });
       return workId;
     });
   }
@@ -155,6 +171,7 @@ describe("loop", () => {
         .collect();
       return {
         running: state?.running ?? [],
+        segmentCursors: state?.segmentCursors,
         lastRecovery: state?.lastRecovery ?? 0n,
         pendingStart,
         pendingCompletion,
@@ -312,6 +329,38 @@ describe("loop", () => {
       expect(o.running.map((r) => r.workId)).not.toContain(finished);
     });
 
+    it("doesn't drop work that shares a commit timestamp with the cursor", async () => {
+      // A batch enqueue commits every row at the same commit timestamp, so the
+      // cursor lands in the middle of a group whenever capacity cuts one short.
+      await initialize({ maxParallelism: 2 });
+      const sharedTimestamp = 1_000n;
+      const ids = [];
+      for (let i = 0; i < 4; i++) {
+        ids.push(await enqueueWork({}, { segment: sharedTimestamp }));
+      }
+
+      const started: Id<"work">[] = [];
+      for (let i = 0; i < 4; i++) {
+        await runLoop();
+        const o = await observe();
+        for (const r of o.running) {
+          if (!started.includes(r.workId)) started.push(r.workId);
+        }
+        for (const r of o.running) {
+          await simulateCompletion(
+            r.workId,
+            { kind: "success", returnValue: null },
+            0,
+          );
+        }
+      }
+      await runLoop();
+
+      // All four ran even though the cursor sat on their shared timestamp.
+      expect(new Set(started)).toEqual(new Set(ids));
+      expect((await observe()).pendingStart).toHaveLength(0);
+    });
+
     it("does not start new work when running.length already exceeds maxParallelism", async () => {
       // Edge case: maxParallelism was lowered while jobs were running.
       await initialize({ maxParallelism: 2 });
@@ -391,6 +440,29 @@ describe("loop", () => {
         state: "pending",
         previousAttempts: 1,
       });
+    });
+
+    it("starts the retry once its backoff elapses, and advances past it", async () => {
+      await initialize();
+      const workId = await enqueueWork({
+        retryBehavior: { maxAttempts: 3, initialBackoffMs: 100, base: 2 },
+      });
+      await runLoop();
+      await simulateCompletion(workId, { kind: "failed", error: "boom" }, 0);
+      await runLoop();
+
+      // Still held back by the backoff: nothing to start yet.
+      expect((await runLoop()).kind).toBe("idle");
+      expect((await observe()).pendingStart).toHaveLength(1);
+
+      // Once the backoff elapses it starts from the not-yet-due lane, and the
+      // lane's cursor moves past it so its tombstone isn't rescanned.
+      vi.advanceTimersByTime(SECOND);
+      await runLoop();
+      const o = await observe();
+      expect(o.pendingStart).toHaveLength(0);
+      expect(o.running.map((r) => r.workId)).toEqual([workId]);
+      expect(o.segmentCursors?.incoming).toBeGreaterThan(0n);
     });
 
     it("does NOT re-enqueue a failed job that was canceled before retry processed", async () => {
@@ -501,10 +573,11 @@ describe("loop", () => {
       expect(result.batch.recovery).toBe(false);
     });
 
-    it("idles with a timeoutMs when only future-scheduled work remains", async () => {
+    it("idles with a timeoutMs when only far-future work remains", async () => {
       await initialize();
-      const future = getCurrentSegment() + 1000n; // 100s out
-      await enqueueWork({}, future);
+      // Beyond SAFE_FUTURE_MS, so the enqueue ordered it by its start time and
+      // the loop never has to look at it.
+      await enqueueWork({}, { runAt: Date.now() + 2 * SAFE_FUTURE_MS });
 
       const result = await t.query(internal.loop.getBatch, {
         name: WORKER_NAME,
@@ -513,13 +586,42 @@ describe("loop", () => {
       expect(result.timeoutMs).toBeGreaterThan(0);
     });
 
+    it("moves near-future work forward once, then idles until it's due", async () => {
+      await initialize();
+      const runAt = Date.now() + 100 * SECOND;
+      // Inside SAFE_FUTURE_MS, so the enqueue had to order it by its commit
+      // timestamp; the loop sees it as eligible exactly once, to move it.
+      const workId = await enqueueWork({}, { runAt });
+
+      const first = await runLoop();
+      assert(first.kind === "work");
+      expect(first.batch.starts.map((s) => s.workId)).toEqual([workId]);
+
+      let o = await observe();
+      expect(o.running).toHaveLength(0); // moved, not started
+      expect(o.pendingStart[0].segment).toBe(toTimestamp(runAt));
+      // The cursor moved past where it used to sit, so it won't come back.
+      expect(o.segmentCursors!.incoming).toBeLessThan(toTimestamp(runAt));
+
+      const second = await runLoop();
+      assert(second.kind === "idle");
+      expect(second.timeoutMs).toBe(100 * SECOND);
+
+      // It starts when it comes due, without another move.
+      vi.advanceTimersByTime(100 * SECOND);
+      await runLoop();
+      o = await observe();
+      expect(o.pendingStart).toHaveLength(0);
+      expect(o.running.map((r) => r.workId)).toEqual([workId]);
+    });
+
     it("idles with a timeoutMs for the next recovery scan when that's sooner than future work", async () => {
       await initialize();
       await enqueueWork();
       await runLoop(); // start it: running=1, lastRecovery=now
 
       // Future work well past the ~1min recovery period.
-      await enqueueWork({}, getCurrentSegment() + toSegment(5 * MINUTE));
+      await enqueueWork({}, { runAt: Date.now() + 2 * SAFE_FUTURE_MS });
 
       const result = await t.query(internal.loop.getBatch, {
         name: WORKER_NAME,

--- a/src/component/loop.test.ts
+++ b/src/component/loop.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_MAX_PARALLELISM,
   fromSegment,
   SAFE_FUTURE_MS,
+  toSegment,
   toTimestamp,
   WORKER_NAME,
 } from "./shared.js";
@@ -360,7 +361,71 @@ describe("loop", () => {
       expect(new Set(started)).toEqual(new Set(ids));
       expect((await observe()).pendingStart).toHaveLength(0);
     });
+  });
 
+  // ────────────────────────────────────────────────────────────────────
+  // Entries written before commit-timestamp ordering
+  // ────────────────────────────────────────────────────────────────────
+
+  describe("upgrade from segment ordering", () => {
+    /** A pendingStart as an older version wrote it: a 100ms bucket, no runAt. */
+    async function enqueueLegacyWork(runAt: number): Promise<Id<"work">> {
+      return t.run(async (ctx) => {
+        const workId = await ctx.db.insert("work", {
+          fnType: "action",
+          fnHandle: "test_handle",
+          fnName: "test_handle",
+          fnArgs: {},
+          attempts: 0,
+        });
+        await ctx.db.insert("pendingStart", {
+          workId,
+          // max(toSegment(runAt), now), as `enqueue` used to compute it.
+          segment: toSegment(Math.max(runAt, Date.now())),
+        });
+        return workId;
+      });
+    }
+
+    it("starts work that was already due", async () => {
+      await initialize();
+      const workId = await enqueueLegacyWork(Date.now());
+
+      await runLoop();
+
+      const o = await observe();
+      expect(o.pendingStart).toHaveLength(0);
+      expect(o.running.map((r) => r.workId)).toEqual([workId]);
+    });
+
+    it("keeps holding work scheduled for later, rather than starting it early", async () => {
+      await initialize();
+      const runAt = Date.now() + 100 * SECOND;
+      const workId = await enqueueLegacyWork(runAt);
+      // The old format only recorded the time to a 100ms bucket.
+      const startsAt = fromSegment(toSegment(runAt));
+
+      await runLoop();
+
+      // Not started — and rewritten as a real timestamp, so the next scan
+      // leaves it alone until it's due.
+      let o = await observe();
+      expect(o.running).toHaveLength(0);
+      expect(o.pendingStart[0].segment).toBe(toTimestamp(startsAt));
+
+      const idle = await runLoop();
+      assert(idle.kind === "idle");
+      expect(idle.timeoutMs).toBe(startsAt - Date.now());
+
+      vi.advanceTimersByTime(startsAt - Date.now());
+      await runLoop();
+      o = await observe();
+      expect(o.pendingStart).toHaveLength(0);
+      expect(o.running.map((r) => r.workId)).toEqual([workId]);
+    });
+  });
+
+  describe("capacity", () => {
     it("does not start new work when running.length already exceeds maxParallelism", async () => {
       // Edge case: maxParallelism was lowered while jobs were running.
       await initialize({ maxParallelism: 2 });

--- a/src/component/loop.test.ts
+++ b/src/component/loop.test.ts
@@ -10,6 +10,8 @@ import {
 } from "vitest";
 import { api, components, internal } from "./_generated/api.js";
 import type { Doc, Id } from "./_generated/dataModel.js";
+import { enqueueHandler } from "./lib.js";
+import { createLogger } from "./logging.js";
 import { RECOVERY_PERIOD_SEGMENTS } from "./loop.js";
 import { setupTest } from "./setup.test.js";
 import {
@@ -97,36 +99,37 @@ describe("loop", () => {
   }
 
   /**
-   * Insert a work doc + pendingStart the way `enqueue` does. `runAt` holds the
-   * work until then; the default runs it as soon as the loop sees it. `segment`
-   * pins the ordering value, e.g. to give several entries the same one the way
-   * a single batch enqueue does.
-   * Bypasses the public enqueue API to keep tests focused on the loop.
+   * Enqueue work through the real `enqueueHandler`, so what the tests write
+   * can't drift from what the public API writes. `runAt` holds the work until
+   * then; the default runs it as soon as the loop sees it. `segment` instead
+   * writes a raw entry pinned to that ordering value, e.g. to give several
+   * entries the same one the way a single batch enqueue does.
    */
   async function enqueueWork(
     overrides: Partial<WithoutSystemFields<Doc<"work">>> = {},
     { runAt, segment }: { runAt?: number; segment?: bigint } = {},
   ): Promise<Id<"work">> {
     return t.run(async (ctx) => {
-      const workId = await ctx.db.insert("work", {
+      if (segment !== undefined) {
+        const workId = await ctx.db.insert("work", {
+          fnType: "action",
+          fnHandle: "test_handle",
+          fnName: "test_handle",
+          fnArgs: {},
+          attempts: 0,
+          ...overrides,
+        });
+        await ctx.db.insert("pendingStart", { workId, segment });
+        return workId;
+      }
+      return enqueueHandler(ctx, createLogger("WARN"), {
         fnType: "action",
         fnHandle: "test_handle",
         fnName: "test_handle",
         fnArgs: {},
-        attempts: 0,
+        runAt: runAt ?? Date.now(),
         ...overrides,
       });
-      const delayMs = (runAt ?? 0) - Date.now();
-      await ctx.db.insert("pendingStart", {
-        workId,
-        segment:
-          segment ??
-          (delayMs > SAFE_FUTURE_MS
-            ? toTimestamp(runAt!)
-            : ctx.db.vars.commitTs),
-        ...(delayMs > 0 ? { runAt } : {}),
-      });
-      return workId;
     });
   }
 
@@ -398,6 +401,38 @@ describe("loop", () => {
       expect(o.running.map((r) => r.workId)).toEqual([workId]);
     });
 
+    it("moves near-future work a pre-lane version left in the main lane", async () => {
+      await initialize();
+      const runAt = Date.now() + 100 * SECOND;
+      // Held at its commit position with `runAt` but no `hasRunAt`: the shape
+      // written before the held lane existed.
+      const workId = await t.run(async (ctx) => {
+        const wid = await ctx.db.insert("work", {
+          fnType: "action",
+          fnHandle: "test_handle",
+          fnName: "test_handle",
+          fnArgs: {},
+          attempts: 0,
+        });
+        await ctx.db.insert("pendingStart", {
+          workId: wid,
+          segment: ctx.db.vars.commitTs,
+          runAt,
+        });
+        return wid;
+      });
+
+      await runLoop();
+
+      const o = await observe();
+      expect(o.running).toHaveLength(0);
+      expect(o.pendingStart[0].segment).toBe(toTimestamp(runAt));
+
+      vi.advanceTimersByTime(100 * SECOND);
+      await runLoop();
+      expect((await observe()).running.map((r) => r.workId)).toEqual([workId]);
+    });
+
     it("keeps holding work scheduled for later, rather than starting it early", async () => {
       await initialize();
       const runAt = Date.now() + 100 * SECOND;
@@ -655,18 +690,23 @@ describe("loop", () => {
       await initialize();
       const runAt = Date.now() + 100 * SECOND;
       // Inside SAFE_FUTURE_MS, so the enqueue had to order it by its commit
-      // timestamp; the loop sees it as eligible exactly once, to move it.
+      // timestamp, in the held lane; the loop sees it there exactly once, to
+      // move it.
       const workId = await enqueueWork({}, { runAt });
 
       const first = await runLoop();
       assert(first.kind === "work");
-      expect(first.batch.starts.map((s) => s.workId)).toEqual([workId]);
+      expect(first.batch.starts).toHaveLength(0);
+      expect(first.batch.scheduled?.map((s) => s.workId)).toEqual([workId]);
 
       let o = await observe();
       expect(o.running).toHaveLength(0); // moved, not started
       expect(o.pendingStart[0].segment).toBe(toTimestamp(runAt));
-      // The cursor moved past where it used to sit, so it won't come back.
-      expect(o.segmentCursors!.incoming).toBeLessThan(toTimestamp(runAt));
+      // Moved out of the held lane, and that lane's cursor moved past where it
+      // used to sit, so it won't come back.
+      expect(o.pendingStart[0].hasRunAt).toBeUndefined();
+      expect(o.segmentCursors!.scheduled).toBeGreaterThan(0n);
+      expect(o.segmentCursors!.scheduled).toBeLessThan(toTimestamp(runAt));
 
       const second = await runLoop();
       assert(second.kind === "idle");
@@ -697,6 +737,92 @@ describe("loop", () => {
         fromSegment(lastRecovery + RECOVERY_PERIOD_SEGMENTS) - Date.now();
       expect(result.timeoutMs).toBe(untilNextRecovery);
       expect(result.timeoutMs).toBeLessThan(5 * MINUTE);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // The held lane: near-future work waiting to be moved to its start time
+  // ────────────────────────────────────────────────────────────────────
+
+  describe("held lane", () => {
+    it("never lets held work sit in front of ready work", async () => {
+      // A bulk enqueue of near-future work lands ahead of anything enqueued
+      // after it, and only MAIN_BATCH_SIZE entries move per iteration. In its
+      // own lane it drains in parallel; in the main lane it would starve the
+      // ready item below for ceil(70/64) iterations.
+      await initialize({ maxParallelism: 3 });
+      const runAt = Date.now() + 100 * SECOND;
+      for (let i = 0; i < 70; i++) await enqueueWork({}, { runAt });
+      const readyId = await enqueueWork();
+
+      await runLoop();
+
+      const o = await observe();
+      expect(o.running.map((r) => r.workId)).toEqual([readyId]);
+      const moved = o.pendingStart.filter((p) => p.hasRunAt === undefined);
+      const held = o.pendingStart.filter((p) => p.hasRunAt === true);
+      expect(moved).toHaveLength(64); // one full batch moved alongside the start
+      expect(held).toHaveLength(6);
+      for (const p of moved) expect(p.segment).toBe(toTimestamp(runAt));
+    });
+
+    it("gives due held work start slots before fetching more ready work", async () => {
+      await initialize({ maxParallelism: 1 });
+      const heldId = await enqueueWork({}, { runAt: Date.now() + SECOND });
+      const readyId = await enqueueWork();
+      vi.advanceTimersByTime(SECOND);
+
+      // The due held entry claims the only slot, so no ready work is fetched.
+      await runLoop();
+      let o = await observe();
+      expect(o.running.map((r) => r.workId)).toEqual([heldId]);
+      expect(o.pendingStart.map((p) => p.workId)).toEqual([readyId]);
+
+      await simulateCompletion(
+        heldId,
+        { kind: "success", returnValue: null },
+        0,
+      );
+      await runLoop();
+      o = await observe();
+      expect(o.pendingStart).toHaveLength(0);
+      expect(o.running.map((r) => r.workId)).toEqual([readyId]);
+    });
+
+    it("starts held work directly once it's due, without moving it", async () => {
+      await initialize();
+      const workId = await enqueueWork({}, { runAt: Date.now() + SECOND });
+
+      vi.advanceTimersByTime(SECOND);
+      await runLoop();
+
+      const o = await observe();
+      expect(o.pendingStart).toHaveLength(0);
+      expect(o.running.map((r) => r.workId)).toEqual([workId]);
+    });
+
+    it("leaves due held work for the iteration that has capacity for it", async () => {
+      await initialize({ maxParallelism: 1 });
+      const firstId = await enqueueWork();
+      await runLoop(); // fills the only slot
+      const heldId = await enqueueWork({}, { runAt: Date.now() + SECOND });
+      vi.advanceTimersByTime(2 * SECOND);
+
+      // Saturated: nothing can start, so the held lane isn't even read.
+      const idle = await runLoop();
+      expect(idle.kind).toBe("idle");
+      expect((await observe()).pendingStart).toHaveLength(1);
+
+      // A completion frees the slot; the same iteration starts the held work.
+      await simulateCompletion(
+        firstId,
+        { kind: "success", returnValue: null },
+        0,
+      );
+      await runLoop();
+      const o = await observe();
+      expect(o.pendingStart).toHaveLength(0);
+      expect(o.running.map((r) => r.workId)).toEqual([heldId]);
     });
   });
 

--- a/src/component/loop.ts
+++ b/src/component/loop.ts
@@ -52,7 +52,12 @@ export const COOLDOWN_CHECK_INTERVAL = 200;
 
 export const INITIAL_STATE: WithoutSystemFields<Doc<"internalState">> = {
   generation: 0n,
-  segmentCursors: { incoming: 0n, completion: 0n, cancelation: 0n },
+  segmentCursors: {
+    incoming: 0n,
+    completion: 0n,
+    cancelation: 0n,
+    scheduled: 0n,
+  },
   lastRecovery: 0n,
   report: {
     completed: 0,
@@ -107,6 +112,10 @@ const batchFields = {
   completions: v.array(vCompletion),
   cancelations: v.array(vCancelation),
   starts: v.array(vStart),
+  // Entries from the `hasRunAt: true` lane: near-future work still ordered by
+  // its enqueue's commit timestamp, waiting to be moved to its start time.
+  // Optional so a batch built just before this field existed still validates.
+  scheduled: v.optional(v.array(vStart)),
 };
 type Batch = Infer<ReturnType<typeof v.object<typeof batchFields>>>;
 
@@ -137,19 +146,24 @@ export const getBatch = internalQuery({
     const isRecoveryIter =
       running.length > 0 && segment - lastRecovery >= RECOVERY_PERIOD_SEGMENTS;
 
-    const { starts, cancelations, completions } = await queryPending(ctx, {
-      completionCursor: cursors.completion,
-      cancelationCursor: cursors.cancelation,
-      incomingCursor: cursors.incoming,
-      maxParallelism: globals.maxParallelism,
-      runningCount: running.length,
-      eligibleBefore,
-    });
+    const { starts, scheduled, cancelations, completions } = await queryPending(
+      ctx,
+      {
+        completionCursor: cursors.completion,
+        cancelationCursor: cursors.cancelation,
+        incomingCursor: cursors.incoming,
+        scheduledCursor: cursors.scheduled ?? 0n,
+        maxParallelism: globals.maxParallelism,
+        runningCount: running.length,
+        eligibleBefore,
+      },
+    );
 
     const hasWork =
       completions.length > 0 ||
       cancelations.length > 0 ||
       starts.length > 0 ||
+      scheduled.length > 0 ||
       isRecoveryIter;
 
     if (hasWork) {
@@ -169,16 +183,22 @@ export const getBatch = internalQuery({
           segment: c.segment as bigint,
         })),
         starts,
+        scheduled,
       };
       return { kind: "work" as const, batch };
     }
 
     // Nothing to do now. Figure out when to wake up next: the sooner of the
     // earliest future-scheduled start and (if jobs are running) the next
-    // recovery scan. A ping still wakes us sooner.
+    // recovery scan. A ping still wakes us sooner. No need to check the
+    // `hasRunAt: true` lane: this iteration read it and it was empty. (The
+    // read is only skipped when the pool is saturated, and then jobs are
+    // running, so the recovery wait applies and completions ping us.)
     const futureStart = await ctx.db
       .query("pendingStart")
-      .withIndex("segment", (q) => q.gte("segment", eligibleBefore))
+      .withIndex("hasRunAt_segment", (q) =>
+        q.eq("hasRunAt", undefined).gte("segment", eligibleBefore),
+      )
       .first();
     const waits: number[] = [];
     if (futureStart) {
@@ -248,12 +268,23 @@ export const run = internalMutation({
     // ── Start new work ──
     // Entries whose `runAt` hasn't arrived were only visible because we
     // couldn't safely write that time into `segment` at enqueue. We can here:
-    // this transaction also writes the cursor, so a value past `now` is
-    // guaranteed to land ahead of it. Move them and they stop coming back.
+    // this transaction also writes the cursors, so a value past `now` is
+    // guaranteed to land ahead of them. Move them and they stop coming back.
     const now = Date.now();
     const isDue = (s: Start) => s.runAt === undefined || s.runAt <= now;
-    const notYet = batch.starts.filter((s) => !isDue(s));
-    const eligible = batch.starts.filter(isDue);
+    const scheduled = batch.scheduled ?? [];
+    const all = [...batch.starts, ...scheduled];
+    const notYet = all.filter((s) => !isDue(s));
+    // Oldest first across both lanes: the main lane's `segment` is when an
+    // entry became eligible, and a due entry from the scheduled lane has been
+    // eligible since its `runAt`.
+    const eligible = all
+      .filter(isDue)
+      .sort(
+        (a, b) =>
+          (a.runAt ?? fromTimestamp(a.segment)) -
+          (b.runAt ?? fromTimestamp(b.segment)),
+      );
     if (notYet.length > 0) {
       const promoteLabel = `[main] promote(${notYet.length})`;
       console.time(promoteLabel);
@@ -301,13 +332,18 @@ export const run = internalMutation({
     if (batch.cancelations.length > 0) {
       state.segmentCursors.cancelation = batch.cancelations.at(-1)!.segment;
     }
-    // Capacity can cut `starts` short, so only advance over the leading run we
-    // finished with — started or moved forward. Stopping at the first entry we
-    // left alone is what keeps it from being skipped.
+    // Capacity can cut the starts short, so only advance each lane's cursor
+    // over the leading run we finished with — started or moved forward.
+    // Stopping at the first entry we left alone is what keeps it from being
+    // skipped.
     const handled = new Set([...pending, ...notYet].map((s) => s._id));
     for (const start of batch.starts) {
       if (!handled.has(start._id)) break;
       state.segmentCursors.incoming = start.segment;
+    }
+    for (const entry of scheduled) {
+      if (!handled.has(entry._id)) break;
+      state.segmentCursors.scheduled = entry.segment;
     }
 
     await ctx.db.replace("internalState", state._id, state);
@@ -324,6 +360,7 @@ async function queryPending(
     completionCursor,
     cancelationCursor,
     incomingCursor,
+    scheduledCursor,
     maxParallelism,
     runningCount,
     eligibleBefore,
@@ -331,6 +368,7 @@ async function queryPending(
     completionCursor: bigint;
     cancelationCursor: bigint;
     incomingCursor: bigint;
+    scheduledCursor: bigint;
     maxParallelism: number;
     runningCount: number;
     eligibleBefore: bigint;
@@ -355,21 +393,48 @@ async function queryPending(
     ...completions.map((c) => c.workId),
     ...cancelations.map((c) => c.workId),
   ];
-  // Everything eligible, oldest first. Work scheduled for later sorts above the
-  // bound, so it's left alone without pinning the cursor.
-  const starts =
+  // Near-future work, still at its enqueue's commit position; `run` moves each
+  // entry to its start time (or starts it, if it came due first). Reading this
+  // lane separately means a backlog of it never sits in front of ready work —
+  // it drains at MAIN_BATCH_SIZE per iteration alongside the starts. Skipped
+  // when nothing can start: an already-due entry only leaves the lane by
+  // starting, so reading it with no capacity would spin the loop.
+  const scheduled =
     startLimit === 0
       ? []
       : await ctx.db
           .query("pendingStart")
-          .withIndex("segment", (q) =>
-            q.gte("segment", incomingCursor).lt("segment", eligibleBefore),
+          .withIndex("hasRunAt_segment", (q) =>
+            q.eq("hasRunAt", true).gte("segment", scheduledCursor),
           )
           // eslint-disable-next-line @convex-dev/no-filter-in-query
           .filter((q) =>
             q.and(...excludedIds.map((id) => q.neq(q.field("workId"), id))),
           )
-          .take(startLimit);
+          .take(MAIN_BATCH_SIZE);
+  // Held entries that are already due take start slots, so only fetch ready
+  // work for the slots left over. Everything eligible, oldest first; work
+  // scheduled for later sorts above the bound, so it's left alone without
+  // pinning the cursor.
+  const now = Date.now();
+  const dueHeld = scheduled.filter((s) => (s.runAt ?? 0) <= now).length;
+  const readyLimit = Math.max(0, startLimit - dueHeld);
+  const starts =
+    readyLimit === 0
+      ? []
+      : await ctx.db
+          .query("pendingStart")
+          .withIndex("hasRunAt_segment", (q) =>
+            q
+              .eq("hasRunAt", undefined)
+              .gte("segment", incomingCursor)
+              .lt("segment", eligibleBefore),
+          )
+          // eslint-disable-next-line @convex-dev/no-filter-in-query
+          .filter((q) =>
+            q.and(...excludedIds.map((id) => q.neq(q.field("workId"), id))),
+          )
+          .take(readyLimit);
   return {
     completions,
     cancelations,
@@ -385,6 +450,12 @@ async function queryPending(
         runAt: s.runAt ?? legacyRunAt(segment),
       };
     }) satisfies Start[],
+    scheduled: scheduled.map((s) => ({
+      _id: s._id,
+      workId: s.workId,
+      segment: s.segment as bigint,
+      runAt: s.runAt,
+    })) satisfies Start[],
   };
 }
 
@@ -560,8 +631,8 @@ async function handleRecovery(
  * Moves entries that aren't due yet to sort at their `runAt` instead of at the
  * commit timestamp they were enqueued with, so the cursor can pass them and
  * they don't come back until they're actually due. Safe to compute from the
- * clock here, unlike at enqueue: this transaction writes the cursor too, so a
- * time past `now` can't end up behind it.
+ * clock here, unlike at enqueue: this transaction writes the cursors too, so a
+ * time past `now` can't end up behind either one.
  */
 async function promoteScheduled(ctx: MutationCtx, notYet: Start[]) {
   await Promise.all(
@@ -569,10 +640,13 @@ async function promoteScheduled(ctx: MutationCtx, notYet: Start[]) {
       // A concurrent cancelation may have removed it.
       if (!(await ctx.db.get("pendingStart", _id))) return;
       await ctx.db.patch("pendingStart", _id, {
-        // Round up to the next whole millisecond: the cursor has already
-        // reached `endOfMs(now)`, so a `runAt` part-way through the current
-        // millisecond would truncate to a timestamp behind it.
+        // Round up to the next whole millisecond: the main-lane cursor has
+        // already reached `endOfMs(now)`, so a `runAt` part-way through the
+        // current millisecond would truncate to a timestamp behind it.
         segment: toTimestamp(Math.ceil(runAt!)),
+        // Now ordered by its start time, so it leaves the held lane and waits
+        // in the main one like any far-future enqueue.
+        hasRunAt: undefined,
       });
     }),
   );

--- a/src/component/loop.ts
+++ b/src/component/loop.ts
@@ -20,12 +20,15 @@ import {
 import {
   type Config,
   DEFAULT_MAX_PARALLELISM,
+  endOfMs,
   fromSegment,
+  fromTimestamp,
   getCurrentSegment,
   MINUTE,
   SECOND,
   type RunResult,
   toSegment,
+  toTimestamp,
   vResult,
 } from "./shared.js";
 import { generateReport, recordCompleted, recordStarted } from "./stats.js";
@@ -45,14 +48,6 @@ export const RECOVERY_PERIOD_SEGMENTS = toSegment(1 * MINUTE); // how often to c
 // cooldown behavior, now expressed via batch-worker's idle hints.
 export const STATUS_COOLDOWN = 2 * SECOND;
 export const COOLDOWN_CHECK_INTERVAL = 200;
-// Buffer applied when querying with cursors. Transactions that started
-// before ours may still be running and commit inserts at segments behind
-// a previously advanced cursor — the buffer lets us pick those up. Most
-// commits land within milliseconds, so a small buffer covers nearly all
-// of them. The minute-cadence recovery iteration scans from segment 0
-// (the start of each pending table) to catch any very-late commit that
-// fell behind even this buffer.
-const CURSOR_BUFFER_SEGMENTS = toSegment(15 * SECOND);
 
 export const INITIAL_STATE: WithoutSystemFields<Doc<"internalState">> = {
   generation: 0n,
@@ -98,6 +93,7 @@ const vStart = v.object({
   _id: v.id("pendingStart"),
   workId: v.id("work"),
   segment: v.int64(),
+  runAt: v.optional(v.number()),
 });
 type Start = Infer<typeof vStart>;
 
@@ -132,34 +128,22 @@ export const getBatch = internalQuery({
     const cursors = state?.segmentCursors ?? INITIAL_STATE.segmentCursors;
     const lastRecovery = state?.lastRecovery ?? INITIAL_STATE.lastRecovery;
     const segment = getCurrentSegment();
+    const eligibleBefore = endOfMs(Date.now());
 
-    // Once per recovery period (≈1min), scan from segment 0 to catch any
-    // very-late commit that fell behind the cursor buffer, and to recover any
-    // stuck running jobs. Otherwise scan from the cursors (minus a buffer for
-    // out-of-order inserts that landed behind the cursor since the last scan).
+    // Once per recovery period (≈1min), check for stuck running jobs. The
+    // pending queues need no periodic rescan: they're ordered by commit
+    // timestamp, so nothing can appear behind a cursor we've read past.
     const isRecoveryIter =
       running.length > 0 && segment - lastRecovery >= RECOVERY_PERIOD_SEGMENTS;
-    const queryArgs = isRecoveryIter
-      ? {
-          completionCursor: 0n,
-          cancelationCursor: 0n,
-          incomingCursor: 0n,
-          maxParallelism: globals.maxParallelism,
-          runningCount: running.length,
-        }
-      : {
-          completionCursor: cursors.completion - CURSOR_BUFFER_SEGMENTS,
-          cancelationCursor: cursors.cancelation - CURSOR_BUFFER_SEGMENTS,
-          incomingCursor: cursors.incoming - CURSOR_BUFFER_SEGMENTS,
-          maxParallelism: globals.maxParallelism,
-          runningCount: running.length,
-        };
 
-    const { allStarts, cancelations, completions } = await queryPending(
-      ctx,
-      queryArgs,
-    );
-    const starts = allStarts.filter((s) => s.segment <= segment);
+    const { starts, cancelations, completions } = await queryPending(ctx, {
+      completionCursor: cursors.completion,
+      cancelationCursor: cursors.cancelation,
+      incomingCursor: cursors.incoming,
+      maxParallelism: globals.maxParallelism,
+      runningCount: running.length,
+      eligibleBefore,
+    });
 
     const hasWork =
       completions.length > 0 ||
@@ -176,18 +160,14 @@ export const getBatch = internalQuery({
           workId: c.workId,
           runResult: c.runResult,
           retry: c.retry,
-          segment: c.segment,
+          segment: c.segment as bigint,
         })),
         cancelations: cancelations.map((c) => ({
           _id: c._id,
           workId: c.workId,
-          segment: c.segment,
+          segment: c.segment as bigint,
         })),
-        starts: starts.map((s) => ({
-          _id: s._id,
-          workId: s.workId,
-          segment: s.segment,
-        })),
+        starts,
       };
       return { kind: "work" as const, batch };
     }
@@ -195,10 +175,13 @@ export const getBatch = internalQuery({
     // Nothing to do now. Figure out when to wake up next: the sooner of the
     // earliest future-scheduled start and (if jobs are running) the next
     // recovery scan. A ping still wakes us sooner.
-    const futureStart = allStarts.find((s) => s.segment > segment);
+    const futureStart = await ctx.db
+      .query("pendingStart")
+      .withIndex("segment", (q) => q.gte("segment", eligibleBefore))
+      .first();
     const waits: number[] = [];
     if (futureStart) {
-      waits.push(fromSegment(futureStart.segment) - Date.now());
+      waits.push(fromTimestamp(futureStart.segment as bigint) - Date.now());
     }
     if (running.length > 0) {
       const nextRecovery = lastRecovery + RECOVERY_PERIOD_SEGMENTS;
@@ -262,11 +245,25 @@ export const run = internalMutation({
     }
 
     // ── Start new work ──
+    // Entries whose `runAt` hasn't arrived were only visible because we
+    // couldn't safely write that time into `segment` at enqueue. We can here:
+    // this transaction also writes the cursor, so a value past `now` is
+    // guaranteed to land ahead of it. Move them and they stop coming back.
+    const now = Date.now();
+    const isDue = (s: Start) => s.runAt === undefined || s.runAt <= now;
+    const notYet = batch.starts.filter((s) => !isDue(s));
+    const eligible = batch.starts.filter(isDue);
+    if (notYet.length > 0) {
+      const promoteLabel = `[main] promote(${notYet.length})`;
+      console.time(promoteLabel);
+      await promoteScheduled(ctx, notYet);
+      console.timeEnd(promoteLabel);
+    }
+
     // Slice to actual available capacity (completions may have freed slots).
     // Guard against negative numbers in case running.length > maxParallelism.
     const actualCapacity = globals.maxParallelism - state.running.length;
-    const pending =
-      actualCapacity > 0 ? batch.starts.slice(0, actualCapacity) : [];
+    const pending = actualCapacity > 0 ? eligible.slice(0, actualCapacity) : [];
     const startLabel = `[main] pendingStart(${pending.length})`;
     console.time(startLabel);
     await handleStart(ctx, state, pending, console, globals);
@@ -295,18 +292,21 @@ export const run = internalMutation({
     }
 
     // Advance cursors to skip tombstones on next scan, but only for the
-    // queues we actually drained this iteration.
+    // queues we actually drained this iteration. The batches came back in
+    // commit order, so the last entry is the furthest we read.
     if (batch.completions.length > 0) {
       state.segmentCursors.completion = batch.completions.at(-1)!.segment;
     }
     if (batch.cancelations.length > 0) {
       state.segmentCursors.cancelation = batch.cancelations.at(-1)!.segment;
     }
-    if (pending.length > 0) {
-      state.segmentCursors.incoming = pending.at(-1)!.segment;
-    } else if (actualCapacity > 0 && batch.starts.length === 0) {
-      // No more pending work to start and we had capacity — advance to now.
-      state.segmentCursors.incoming = segment;
+    // Capacity can cut `starts` short, so only advance over the leading run we
+    // finished with — started or moved forward. Stopping at the first entry we
+    // left alone is what keeps it from being skipped.
+    const handled = new Set([...pending, ...notYet].map((s) => s._id));
+    for (const start of batch.starts) {
+      if (!handled.has(start._id)) break;
+      state.segmentCursors.incoming = start.segment;
     }
 
     await ctx.db.replace("internalState", state._id, state);
@@ -325,12 +325,14 @@ async function queryPending(
     incomingCursor,
     maxParallelism,
     runningCount,
+    eligibleBefore,
   }: {
     completionCursor: bigint;
     cancelationCursor: bigint;
     incomingCursor: bigint;
     maxParallelism: number;
     runningCount: number;
+    eligibleBefore: bigint;
   },
 ) {
   const completions = await ctx.db
@@ -341,10 +343,9 @@ async function queryPending(
     .query("pendingCancelation")
     .withIndex("segment", (q) => q.gte("segment", cancelationCursor))
     .take(CANCELLATION_BATCH_SIZE);
-  // Available slots after we process this batch's completions, plus 1
-  // for the +1 trick (detect overflow vs. a future-scheduled retry).
-  // Cap at MAIN_BATCH_SIZE so a single iteration's per-item writes
-  // (delete pendingStart + scheduler.runAfter) don't grow unbounded.
+  // Available slots after we process this batch's completions. Cap at
+  // MAIN_BATCH_SIZE so a single iteration's per-item writes (delete
+  // pendingStart + scheduler.runAfter) don't grow unbounded.
   const startLimit = Math.min(
     MAIN_BATCH_SIZE,
     Math.max(0, maxParallelism - runningCount + completions.length),
@@ -353,18 +354,31 @@ async function queryPending(
     ...completions.map((c) => c.workId),
     ...cancelations.map((c) => c.workId),
   ];
-  const allStarts =
+  // Everything eligible, oldest first. Work scheduled for later sorts above the
+  // bound, so it's left alone without pinning the cursor.
+  const starts =
     startLimit === 0
       ? []
       : await ctx.db
           .query("pendingStart")
-          .withIndex("segment", (q) => q.gte("segment", incomingCursor))
+          .withIndex("segment", (q) =>
+            q.gte("segment", incomingCursor).lt("segment", eligibleBefore),
+          )
           // eslint-disable-next-line @convex-dev/no-filter-in-query
           .filter((q) =>
             q.and(...excludedIds.map((id) => q.neq(q.field("workId"), id))),
           )
-          .take(startLimit + 1);
-  return { completions, cancelations, allStarts };
+          .take(startLimit);
+  return {
+    completions,
+    cancelations,
+    starts: starts.map((s) => ({
+      _id: s._id,
+      workId: s.workId,
+      segment: s.segment as bigint,
+      runAt: s.runAt,
+    })) satisfies Start[],
+  };
 }
 
 /**
@@ -461,6 +475,13 @@ async function handleCancelation(
           const work = await ctx.db.get("work", workId);
           if (!work) {
             console.warn(`[main] ${workId} is gone, but trying to cancel`);
+            // Drop any pendingStart left pointing at it. Nothing rescans that
+            // lane, so a row left behind here would never be read again.
+            const orphan = await ctx.db
+              .query("pendingStart")
+              .withIndex("workId", (q) => q.eq("workId", workId))
+              .unique();
+            if (orphan) await ctx.db.delete("pendingStart", orphan._id);
             return null;
           }
           // Ensure it doesn't retry.
@@ -529,6 +550,28 @@ async function handleRecovery(
 }
 
 /**
+ * Moves entries that aren't due yet to sort at their `runAt` instead of at the
+ * commit timestamp they were enqueued with, so the cursor can pass them and
+ * they don't come back until they're actually due. Safe to compute from the
+ * clock here, unlike at enqueue: this transaction writes the cursor too, so a
+ * time past `now` can't end up behind it.
+ */
+async function promoteScheduled(ctx: MutationCtx, notYet: Start[]) {
+  await Promise.all(
+    notYet.map(async ({ _id, runAt }) => {
+      // A concurrent cancelation may have removed it.
+      if (!(await ctx.db.get("pendingStart", _id))) return;
+      await ctx.db.patch("pendingStart", _id, {
+        // Round up to the next whole millisecond: the cursor has already
+        // reached `endOfMs(now)`, so a `runAt` part-way through the current
+        // millisecond would truncate to a timestamp behind it.
+        segment: toTimestamp(Math.ceil(runAt!)),
+      });
+    }),
+  );
+}
+
+/**
  * Starts pending work.
  */
 async function handleStart(
@@ -541,9 +584,14 @@ async function handleStart(
   console.debug(`[main] scheduling ${pending.length} pending work`);
   const starts = (
     await Promise.all(
-      pending.map(async ({ _id, workId, segment }) => {
+      pending.map(async ({ _id, workId, segment, runAt }) => {
         if (state.running.some((r) => r.workId === workId)) {
           console.error(`[main] ${workId} already running (skipping start)`);
+          // The row is spurious, and nothing rescans the lane behind the
+          // cursor, so drop it rather than leave it unreadable.
+          if (await ctx.db.get("pendingStart", _id)) {
+            await ctx.db.delete("pendingStart", _id);
+          }
           return null;
         }
         // Guard against a pendingStart a concurrent cancelation removed.
@@ -558,7 +606,9 @@ async function handleStart(
         }
         return {
           work,
-          lagMs: Date.now() - fromSegment(segment),
+          // `segment` is when this became eligible: the time it was scheduled
+          // for, or the commit timestamp of the enqueue if it was ready then.
+          lagMs: Date.now() - (runAt ?? fromTimestamp(segment)),
         };
       }),
     )
@@ -690,11 +740,12 @@ async function rescheduleJob(
     work.retryBehavior.initialBackoffMs *
     Math.pow(work.retryBehavior.base, work.attempts - 1);
   const nextAttempt = withJitter(backoffMs);
-  const startTime = Date.now() + nextAttempt;
-  const segment = toSegment(startTime);
+  // The backoff can go straight into `segment` however short it is: we're in
+  // the transaction that writes the cursor, so a time past now is certain to
+  // sort ahead of it. No `runAt` needed — `segment` already is the start time.
   await ctx.db.insert("pendingStart", {
     workId: work._id,
-    segment,
+    segment: toTimestamp(Date.now() + nextAttempt),
   });
   return true;
 }

--- a/src/component/loop.ts
+++ b/src/component/loop.ts
@@ -24,6 +24,7 @@ import {
   fromSegment,
   fromTimestamp,
   getCurrentSegment,
+  legacyRunAt,
   MINUTE,
   SECOND,
   type RunResult,
@@ -372,12 +373,18 @@ async function queryPending(
   return {
     completions,
     cancelations,
-    starts: starts.map((s) => ({
-      _id: s._id,
-      workId: s.workId,
-      segment: s.segment as bigint,
-      runAt: s.runAt,
-    })) satisfies Start[],
+    starts: starts.map((s) => {
+      const segment = s.segment as bigint;
+      return {
+        _id: s._id,
+        workId: s.workId,
+        segment,
+        // An entry from before commit-timestamp ordering keeps its start time
+        // in `segment`; recovering it here means `run` handles it like any
+        // other scheduled entry and rewrites it as a timestamp.
+        runAt: s.runAt ?? legacyRunAt(segment),
+      };
+    }) satisfies Start[],
   };
 }
 

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -41,6 +41,9 @@ export default defineSchema({
       incoming: timestamp,
       completion: timestamp,
       cancelation: timestamp,
+      // Cursor into pendingStart's `hasRunAt: true` lane. Optional because it
+      // didn't exist before that lane did; absent means "from the beginning".
+      scheduled: v.optional(timestamp),
     }),
     // Unlike the cursors, this stays a 100ms "segment": it only paces how often
     // the loop checks for stuck jobs.
@@ -88,9 +91,17 @@ export default defineSchema({
     // cursor — `segment` is the commit timestamp and this is what tells the
     // loop to move the entry forward instead of starting it.
     runAt: v.optional(v.number()),
+    // Set (to true) on exactly the entries described above: held at their
+    // commit position awaiting a move to their start time. It splits the index
+    // into two lanes so those entries never sit in front of ready work — the
+    // loop drains this lane in parallel with starting work from the other.
+    // Entries whose `segment` is already their start time don't need it, and
+    // its absence puts entries older versions wrote in the main lane, where
+    // the legacy handling lives.
+    hasRunAt: v.optional(v.boolean()),
   })
     .index("workId", ["workId"])
-    .index("segment", ["segment"]),
+    .index("hasRunAt_segment", ["hasRunAt", "segment"]),
 
   // Written by complete, read & deleted by `main`.
   pendingCompletion: defineTable({

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -8,8 +8,22 @@ import {
   vResult,
 } from "./shared.js";
 
-// Represents a slice of time to process work.
-const segment = v.int64();
+// When a queue entry becomes eligible to process, in nanoseconds since the
+// epoch — the scale a commit timestamp uses.
+//
+// Entries that are ready as soon as they land store `db.vars.commitTs`, which
+// resolves at commit time. That's what makes an index on this field scannable
+// with a cursor that never has to be rewound: an entry can't appear behind a
+// commit timestamp we've already read past. (`_creationTime` can't do this — it
+// is assigned when the mutation *starts*, so a slow mutation's row can land
+// behind rows that already committed and were read.)
+//
+// Entries that shouldn't be processed until later store that time directly,
+// which sorts after everything committed before then. `v.commitTs()` accepts any
+// int64, so both live in one field and one index.
+const segment = v.commitTs();
+// A cursor into a `segment` index. Reads of the field come back as a plain int64.
+const timestamp = v.int64();
 
 export default defineSchema({
   // Written from kickLoop, read everywhere.
@@ -19,13 +33,18 @@ export default defineSchema({
     // @deprecated batch-worker now owns the generation guard. We keep writing
     // `0n` for rollback compatibility with older workpool versions.
     generation: v.optional(v.int64()),
-    // Track where we've scanned to, so we skip tombstones on re-scan.
+    // Track where we've scanned to, so we skip tombstones on re-scan. Same
+    // field as older versions used for its wall-clock cursors, so their data
+    // still validates — the values are now commit timestamps, and an older
+    // version's much smaller ones just mean "scan from the beginning".
     segmentCursors: v.object({
-      incoming: segment,
-      completion: segment,
-      cancelation: segment,
+      incoming: timestamp,
+      completion: timestamp,
+      cancelation: timestamp,
     }),
-    lastRecovery: segment,
+    // Unlike the cursors, this stays a 100ms "segment": it only paces how often
+    // the loop checks for stuck jobs.
+    lastRecovery: v.int64(),
     report: v.object({
       completed: v.number(), // finished running, counts retries & failures
       succeeded: v.number(), // finished successfully, regardless of retries
@@ -63,6 +82,12 @@ export default defineSchema({
   pendingStart: defineTable({
     workId: v.id("work"),
     segment,
+    // Only set when the work shouldn't start yet. `segment` already holds that
+    // time whenever we could safely write it there; when we couldn't — a
+    // caller-supplied `runAt` too near to be sure it lands ahead of the loop's
+    // cursor — `segment` is the commit timestamp and this is what tells the
+    // loop to move the entry forward instead of starting it.
+    runAt: v.optional(v.number()),
   })
     .index("workId", ["workId"])
     .index("segment", ["segment"]),

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -35,6 +35,57 @@ export function fromSegment(segment: bigint): number {
   return Number(segment) * SEGMENT_MS;
 }
 
+// A commit timestamp is nanoseconds since the epoch, so a wall-clock time
+// converts into the same ordering as one. This is what lets a single index hold
+// both "ready as soon as it commits" and "not before this time".
+const NS_PER_MS = 1_000_000n;
+
+/**
+ * A wall-clock time on the commit-timestamp scale. `Date.now()` is whole
+ * milliseconds in Convex, so nothing is lost converting it; the floor only
+ * rounds a caller-supplied fractional `runAt`, and never upward, so work can't
+ * be held past its time.
+ */
+export function toTimestamp(ms: number): bigint {
+  return BigInt(Math.floor(ms)) * NS_PER_MS;
+}
+
+/** Back to whole milliseconds, the resolution `Date.now()` reports. */
+export function fromTimestamp(timestamp: bigint): number {
+  return Number(timestamp / NS_PER_MS);
+}
+
+/**
+ * The exclusive upper bound on entries eligible at `ms` — the end of that
+ * millisecond, not the start of it.
+ *
+ * The clock and the timestamps it gets compared against have different
+ * resolutions: `Date.now()` is whole milliseconds, but a commit timestamp is
+ * not. A row committing during millisecond `now` lands *above*
+ * `toTimestamp(now)` (a transaction's timestamp measures ~0.2ms above its own
+ * `Date.now()`), so bounding there would skip everything that committed this
+ * millisecond — thousands of rows under load. Scheduled times are whole
+ * milliseconds, so extending to the end of the millisecond can't let
+ * not-yet-due work through.
+ */
+export function endOfMs(ms: number): bigint {
+  return toTimestamp(Math.floor(ms) + 1);
+}
+
+/**
+ * How far ahead a caller-supplied `runAt` has to be before we can write it
+ * straight into the ordering field.
+ *
+ * Writing a wall-clock time there is only safe if the value is guaranteed to
+ * land after every commit timestamp the loop has already read. The time is
+ * chosen when the enqueue *starts*, so the margin has to cover however long
+ * that transaction then takes to commit. Five minutes is far longer than any
+ * mutation can run, so a `runAt` beyond it cannot land in the past. Anything
+ * nearer is written as `db.vars.commitTs` plus a `runAt` field, and the loop
+ * moves it forward itself — see `promoteScheduled` in loop.ts.
+ */
+export const SAFE_FUTURE_MS = 5 * MINUTE;
+
 export const vConfig = v.object({
   maxParallelism: v.number(),
   logLevel,
@@ -138,18 +189,4 @@ export function boundScheduledTime(ms: number, console: Logger): number {
     return Date.now() + YEAR;
   }
   return ms;
-}
-
-/**
- * Returns the smaller of two bigint values.
- */
-export function min<T extends bigint>(a: T, b: T): T {
-  return a > b ? b : a;
-}
-
-/**
- * Returns the larger of two bigint values.
- */
-export function max<T extends bigint>(a: T, b: T): T {
-  return a < b ? b : a;
 }

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -72,6 +72,26 @@ export function endOfMs(ms: number): bigint {
   return toTimestamp(Math.floor(ms) + 1);
 }
 
+// Nanoseconds for the year 2000: far above any 100ms bucket an older version
+// could have written (~1.8e10 today, ~1.9e10 even four years out) and far below
+// any timestamp this one can produce, since `boundScheduledTime` keeps
+// scheduled times within a few years of now. Nothing real lands in between.
+const MIN_TIMESTAMP = toTimestamp(Date.UTC(2000, 0, 1));
+
+/**
+ * The start time a `pendingStart` written before commit-timestamp ordering
+ * represents, or undefined if its `segment` is already a timestamp.
+ *
+ * Those entries stored `max(toSegment(runAt), toSegment(now))` and had no
+ * `runAt` field, so the bucket is the only record of when the work should
+ * start — and it may still be in the future. Reading it back as a time lets the
+ * loop treat such an entry like any other scheduled one, rather than seeing a
+ * value far below the eligibility bound and starting it immediately.
+ */
+export function legacyRunAt(segment: bigint): number | undefined {
+  return segment < MIN_TIMESTAMP ? fromSegment(segment) : undefined;
+}
+
 /**
  * How far ahead a caller-supplied `runAt` has to be before we can write it
  * straight into the ordering field.

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -101,8 +101,10 @@ export function legacyRunAt(segment: bigint): number | undefined {
  * chosen when the enqueue *starts*, so the margin has to cover however long
  * that transaction then takes to commit. Five minutes is far longer than any
  * mutation can run, so a `runAt` beyond it cannot land in the past. Anything
- * nearer is written as `db.vars.commitTs` plus a `runAt` field, and the loop
- * moves it forward itself — see `promoteScheduled` in loop.ts.
+ * nearer is ordered by `db.vars.commitTs` instead, keeps its `runAt` in a
+ * separate field, and is marked `hasRunAt` so it sits in its own index lane.
+ * The loop then moves it to its start time itself, which is safe there; see
+ * `promoteScheduled` in loop.ts.
  */
 export const SAFE_FUTURE_MS = 5 * MINUTE;
 

--- a/src/component/stateMachine.test.ts
+++ b/src/component/stateMachine.test.ts
@@ -247,7 +247,11 @@ describe("state machine", () => {
         : getCurrentSegment();
       await ctx.db.insert("internalState", {
         generation: 0n,
-        segmentCursors: { incoming: 0n, completion: 0n, cancelation: 0n },
+        segmentCursors: {
+          incoming: 0n,
+          completion: 0n,
+          cancelation: 0n,
+        },
         lastRecovery,
         report: {
           completed: 0,
@@ -262,7 +266,10 @@ describe("state machine", () => {
 
       // pendingStart
       if (state.pendingStart) {
-        await ctx.db.insert("pendingStart", { workId: wId, segment: seg });
+        await ctx.db.insert("pendingStart", {
+          workId: wId,
+          segment: seg,
+        });
       }
 
       // pendingCompletion
@@ -747,7 +754,7 @@ describe("state machine", () => {
       expect(s.running).toBe(false);
     });
 
-    it("pendingStart + running for same workId -> skips start but leaves pendingStart", async () => {
+    it("pendingStart + running for same workId -> skips start and drops the pendingStart", async () => {
       const { workId, segment } = await setupState({
         work: { attempts: 0, hasRetryBehavior: false, fnType: "action" },
         pendingStart: true,
@@ -758,10 +765,10 @@ describe("state machine", () => {
       await runLoop(segment);
       const s = await observeState(workId);
       expect(s.running).toBe(true);
-      // BUG: handleStart skips the start but does NOT delete the pendingStart
-      // entry (returns null before the delete call). This means the orphaned
-      // pendingStart will be picked up again on the next loop iteration.
-      expect(s.pendingStart).toBe(true);
+      // The pendingStart is spurious — the work is already running — and the
+      // ready lane's cursor has moved past it, so it has to be deleted here or
+      // it would sit in the table unread forever.
+      expect(s.pendingStart).toBe(false);
     });
 
     it("duplicate pendingCompletion via complete.complete -> BUG: attempts still incremented", async () => {
@@ -808,7 +815,10 @@ describe("state machine", () => {
           fnArgs: {},
           attempts: 0,
         });
-        await ctx.db.insert("pendingStart", { workId: id, segment: seg });
+        await ctx.db.insert("pendingStart", {
+          workId: id,
+          segment: seg,
+        });
         return id;
       });
 
@@ -865,7 +875,11 @@ describe("state machine", () => {
         );
         await ctx.db.insert("internalState", {
           generation: 0n,
-          segmentCursors: { incoming: 0n, completion: 0n, cancelation: 0n },
+          segmentCursors: {
+            incoming: 0n,
+            completion: 0n,
+            cancelation: 0n,
+          },
           lastRecovery: getCurrentSegment(),
           report: {
             completed: 0,
@@ -926,7 +940,7 @@ describe("state machine", () => {
       await t.run(async (ctx) => {
         await ctx.db.insert("pendingCancelation", {
           workId,
-          segment,
+          segment: segment,
         });
       });
 
@@ -947,7 +961,10 @@ describe("state machine", () => {
           fnArgs: {},
           attempts: 0,
         });
-        await ctx.db.insert("pendingStart", { workId: wId, segment: seg });
+        await ctx.db.insert("pendingStart", {
+          workId: wId,
+          segment: seg,
+        });
         await ctx.db.insert("pendingCancelation", {
           workId: wId,
           segment: seg,
@@ -959,7 +976,11 @@ describe("state machine", () => {
 
         await ctx.db.insert("internalState", {
           generation: 0n,
-          segmentCursors: { incoming: 0n, completion: 0n, cancelation: 0n },
+          segmentCursors: {
+            incoming: 0n,
+            completion: 0n,
+            cancelation: 0n,
+          },
           lastRecovery: getCurrentSegment(),
           report: {
             completed: 0,
@@ -1017,7 +1038,11 @@ describe("state machine", () => {
         );
         await ctx.db.insert("internalState", {
           generation: 0n,
-          segmentCursors: { incoming: 0n, completion: 0n, cancelation: 0n },
+          segmentCursors: {
+            incoming: 0n,
+            completion: 0n,
+            cancelation: 0n,
+          },
           lastRecovery: getCurrentSegment(),
           report: {
             completed: 0,
@@ -1107,7 +1132,11 @@ describe("state machine", () => {
 
         await ctx.db.insert("internalState", {
           generation: 0n,
-          segmentCursors: { incoming: 0n, completion: 0n, cancelation: 0n },
+          segmentCursors: {
+            incoming: 0n,
+            completion: 0n,
+            cancelation: 0n,
+          },
           lastRecovery: getCurrentSegment(),
           report: {
             completed: 0,
@@ -1126,12 +1155,18 @@ describe("state machine", () => {
           retry: false,
           runResult: { kind: "success", returnValue: null },
         });
-        await ctx.db.insert("pendingStart", { workId: w2, segment: seg });
+        await ctx.db.insert("pendingStart", {
+          workId: w2,
+          segment: seg,
+        });
         await ctx.db.insert("pendingCancelation", {
           workId: w2,
           segment: seg,
         });
-        await ctx.db.insert("pendingStart", { workId: w3, segment: seg });
+        await ctx.db.insert("pendingStart", {
+          workId: w3,
+          segment: seg,
+        });
 
         return { w1, w2, w3 };
       });
@@ -1184,7 +1219,11 @@ describe("state machine", () => {
         );
         await ctx.db.insert("internalState", {
           generation: 0n,
-          segmentCursors: { incoming: 0n, completion: 0n, cancelation: 0n },
+          segmentCursors: {
+            incoming: 0n,
+            completion: 0n,
+            cancelation: 0n,
+          },
           lastRecovery: getCurrentSegment(),
           report: {
             completed: 0,

--- a/src/component/stats.test.ts
+++ b/src/component/stats.test.ts
@@ -305,7 +305,9 @@ describe("stats", () => {
       const cursor = await t.run(async (ctx) => {
         return await paginator(ctx.db, schema)
           .query("pendingStart")
-          .withIndex("segment", (q) => q.gte("segment", 0n))
+          .withIndex("hasRunAt_segment", (q) =>
+            q.eq("hasRunAt", undefined).gte("segment", 0n),
+          )
           .paginate({
             numItems: 1,
             cursor: null,

--- a/src/component/stats.test.ts
+++ b/src/component/stats.test.ts
@@ -305,9 +305,7 @@ describe("stats", () => {
       const cursor = await t.run(async (ctx) => {
         return await paginator(ctx.db, schema)
           .query("pendingStart")
-          .withIndex("segment", (q) =>
-            q.gte("segment", 0n).lt("segment", currentSegment),
-          )
+          .withIndex("segment", (q) => q.gte("segment", 0n))
           .paginate({
             numItems: 1,
             cursor: null,

--- a/src/component/stats.ts
+++ b/src/component/stats.ts
@@ -8,6 +8,7 @@ import {
 import {
   type Config,
   DEFAULT_MAX_PARALLELISM,
+  endOfMs,
   getCurrentSegment,
   WORKER_NAME,
 } from "./shared.js";
@@ -78,12 +79,14 @@ export async function generateReport(
     return;
   }
   const currentSegment = getCurrentSegment();
+  // Backlog is work that's eligible now; anything scheduled for later sorts
+  // above the current time and isn't waiting on us.
   const pendingStart = await paginator(ctx.db, schema)
     .query("pendingStart")
     .withIndex("segment", (q) =>
       q
         .gte("segment", state.segmentCursors.incoming)
-        .lt("segment", currentSegment),
+        .lt("segment", endOfMs(Date.now())),
     )
     .paginate({
       numItems: Math.max(maxParallelism, 10),

--- a/src/component/stats.ts
+++ b/src/component/stats.ts
@@ -80,11 +80,13 @@ export async function generateReport(
   }
   const currentSegment = getCurrentSegment();
   // Backlog is work that's eligible now; anything scheduled for later sorts
-  // above the current time and isn't waiting on us.
+  // above the current time — or sits in the held `hasRunAt` lane — and isn't
+  // waiting on us.
   const pendingStart = await paginator(ctx.db, schema)
     .query("pendingStart")
-    .withIndex("segment", (q) =>
+    .withIndex("hasRunAt_segment", (q) =>
       q
+        .eq("hasRunAt", undefined)
         .gte("segment", state.segmentCursors.incoming)
         .lt("segment", endOfMs(Date.now())),
     )


### PR DESCRIPTION
Order ready work, completions, and cancellations by commit timestamp. A sweep finds scheduled enqueues that commit behind the incoming cursor, which stays bounded by the transaction snapshot.

Upgrade legacy keys and pointers before scanning, preserving their original time ordering. Requires Convex 1.43.

Validation: 162 tests pass; build, typecheck, lint, and changed-file formatting pass.
