### PR TITLE
add vRunResult for type-safe onComplete

### DIFF
--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -286,17 +286,19 @@ export const noopAction = internalAction({
 
 // Another way to define the onComplete mutation.
 export const complete = internalMutation({
-  args: vOnCompleteArgs(v.number()),
+  args: vOnCompleteArgs(v.number(), v.union(v.number(), v.array(v.number()))),
   handler: async (ctx, args) => {
     if (args.result.kind === "success") {
-      console.warn("onComplete delay", Date.now() - args.result.returnValue);
+      if (typeof args.result.returnValue === "number") {
+        console.warn("onComplete delay", Date.now() - args.result.returnValue);
+      }
     }
     console.warn("total", (Date.now() - args.context) / 1000);
   },
 });
 
 export const completeFail = internalMutation({
-  args: vOnCompleteArgs(v.number()),
+  args: vOnCompleteArgs(v.number(), v.number()),
   handler: async (ctx) => {
     console.info("completeFail");
     for (let i = 0; i < 16000; i++) {

--- a/example/convex/test/pool.ts
+++ b/example/convex/test/pool.ts
@@ -33,9 +33,9 @@ export async function configurePool(
 export function makePool(
   kind: PoolKind,
   opts: { maxParallelism: number },
-): Workpool | OldWorkpool {
+): Workpool {
   if (kind === "new") return new Workpool(components.testWorkpool, opts);
-  return new OldWorkpool(components.oldWorkpool, opts);
+  return new OldWorkpool(components.oldWorkpool, opts) as Workpool;
 }
 
 export function getComponent(kind: PoolKind) {
@@ -56,7 +56,7 @@ export function enqueueFor(kind: PoolKind): {
   }
   return {
     component: components.oldWorkpool,
-    enqueueOne: enqueueOld,
-    enqueueMany: enqueueBatchOld,
+    enqueueOne: enqueueOld as typeof enqueue,
+    enqueueMany: enqueueBatchOld as typeof enqueueBatch,
   };
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -92,7 +92,7 @@ export class Workpool {
    *   onComplete handling, and scheduling via `runAt` or `runAfter`.
    * @returns The ID of the work that was enqueued.
    */
-  async enqueueAction<Args extends DefaultFunctionArgs, ReturnType, Context>(
+  async enqueueAction<Args extends DefaultFunctionArgs, Context, ReturnType>(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<
       "action",
@@ -129,8 +129,8 @@ export class Workpool {
    */
   async enqueueActionBatch<
     Args extends DefaultFunctionArgs,
-    ReturnType,
     Context,
+    ReturnType,
   >(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<
@@ -167,7 +167,7 @@ export class Workpool {
    * @param options - The options for the mutation to specify onComplete handling
    *   and scheduling via `runAt` or `runAfter`.
    */
-  async enqueueMutation<Args extends DefaultFunctionArgs, ReturnType, Context>(
+  async enqueueMutation<Args extends DefaultFunctionArgs, Context, ReturnType>(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<
       "mutation",
@@ -196,8 +196,8 @@ export class Workpool {
    */
   async enqueueMutationBatch<
     Args extends DefaultFunctionArgs,
-    ReturnType,
     Context,
+    ReturnType,
   >(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<
@@ -227,7 +227,7 @@ export class Workpool {
    * @param options - The options for the query to specify onComplete handling
    *   and scheduling via `runAt` or `runAfter`.
    */
-  async enqueueQuery<Args extends DefaultFunctionArgs, ReturnType, Context>(
+  async enqueueQuery<Args extends DefaultFunctionArgs, Context, ReturnType>(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<
       "query",
@@ -257,8 +257,8 @@ export class Workpool {
    */
   async enqueueQueryBatch<
     Args extends DefaultFunctionArgs,
-    ReturnType,
     Context,
+    ReturnType,
   >(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<
@@ -356,26 +356,26 @@ export class Workpool {
    */
   defineOnComplete<
     DataModel extends GenericDataModel,
-    V extends Validator<any, any, any> = VAny<any, "optional">,
-    RV extends Validator<any, any, any> = VAny<any, "optional">,
+    VContext extends Validator<any, any, any> = VAny<any, "optional">,
+    VReturnValue extends Validator<any, any, any> = VAny<any, "optional">,
   >({
     context,
     handler,
     returnValue,
   }: {
-    context?: V;
+    context?: VContext;
     handler: (
       ctx: GenericMutationCtx<DataModel>,
       args: {
         workId: WorkId;
-        context: Infer<V>;
-        result: RunResult<Infer<RV>>;
+        context: Infer<VContext>;
+        result: RunResult<Infer<VReturnValue>>;
       },
     ) => Promise<void>;
-    returnValue?: RV;
+    returnValue?: VReturnValue;
   }): RegisteredMutation<
     "internal",
-    OnCompleteArgs<Infer<V>, Infer<RV>>,
+    OnCompleteArgs<Infer<VContext>, Infer<VReturnValue>>,
     null
   > {
     return internalMutationGeneric({
@@ -400,13 +400,15 @@ export class Workpool {
  * @returns The validator for the onComplete mutation.
  */
 export function vOnCompleteArgs<
-  V extends Validator<any, "required", any> = VAny,
-  RV extends Validator<any, "required", any> = VAny,
->(context?: V, runResult?: RV) {
+  VContext extends Validator<any, "required", any> = VAny,
+  VReturn extends Validator<any, "required", any> = VAny,
+>(context?: VContext, runResult?: VReturn) {
   return v.object({
     workId: vWorkId,
-    context: (context ?? v.optional(v.any())) as V,
-    result: vRunResult<RV>(runResult ?? (v.optional(v.any()) as unknown as RV)),
+    context: (context ?? v.optional(v.any())) as VContext,
+    result: vRunResult(
+      runResult ?? (v.optional(v.any()) as unknown as VReturn),
+    ),
   });
 }
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -454,7 +454,7 @@ export type WorkpoolRetryOptions = {
   retryActionsByDefault?: boolean;
 };
 
-export type EnqueueOptions<Context, ReturnValue> = {
+export type EnqueueOptions<Context = unknown, ReturnValue = unknown> = {
   /**
    * The name of the function. By default, if you pass in api.foo.bar.baz,
    * it will use "foo/bar:baz" as the name. If you pass in a function handle,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -96,7 +96,7 @@ export class Workpool {
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"action", FunctionVisibility, Args, ReturnType>,
     fnArgs: Args,
-    options?: RetryOption & EnqueueOptions,
+    options?: RetryOption & EnqueueOptions<ReturnType>,
   ): Promise<WorkId> {
     const retryBehavior = getRetryBehavior(
       this.options.defaultRetryBehavior,
@@ -126,7 +126,7 @@ export class Workpool {
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"action", FunctionVisibility, Args, ReturnType>,
     argsArray: Array<Args>,
-    options?: RetryOption & EnqueueOptions,
+    options?: RetryOption & EnqueueOptions<ReturnType>,
   ): Promise<WorkId[]> {
     const retryBehavior = getRetryBehavior(
       this.options.defaultRetryBehavior,
@@ -157,7 +157,7 @@ export class Workpool {
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"mutation", FunctionVisibility, Args, ReturnType>,
     fnArgs: Args,
-    options?: EnqueueOptions,
+    options?: EnqueueOptions<ReturnType>,
   ): Promise<WorkId> {
     return enqueue(this.component, ctx, "mutation", fn, fnArgs, {
       ...this.options,
@@ -179,7 +179,7 @@ export class Workpool {
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"mutation", FunctionVisibility, Args, ReturnType>,
     argsArray: Array<Args>,
-    options?: EnqueueOptions,
+    options?: EnqueueOptions<ReturnType>,
   ): Promise<WorkId[]> {
     return enqueueBatch(this.component, ctx, "mutation", fn, argsArray, {
       ...this.options,
@@ -203,7 +203,7 @@ export class Workpool {
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"query", FunctionVisibility, Args, ReturnType>,
     fnArgs: Args,
-    options?: EnqueueOptions,
+    options?: EnqueueOptions<ReturnType>,
   ): Promise<WorkId> {
     return enqueue(this.component, ctx, "query", fn, fnArgs, {
       ...this.options,
@@ -226,7 +226,7 @@ export class Workpool {
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"query", FunctionVisibility, Args, ReturnType>,
     argsArray: Array<Args>,
-    options?: EnqueueOptions,
+    options?: EnqueueOptions<ReturnType>,
   ): Promise<WorkId[]> {
     return enqueueBatch(this.component, ctx, "query", fn, argsArray, {
       ...this.options,
@@ -364,7 +364,7 @@ export function vOnCompleteArgs<
   return v.object({
     workId: vWorkId,
     context: (context ?? v.optional(v.any())) as V,
-    result: vRunResult(runResult ?? v.optional(v.any())),
+    result: vRunResult<RV>(runResult ?? (v.optional(v.any()) as unknown as RV)),
   });
 }
 
@@ -410,7 +410,7 @@ export type WorkpoolRetryOptions = {
   retryActionsByDefault?: boolean;
 };
 
-export type EnqueueOptions = {
+export type EnqueueOptions<ReturnValue, Context = unknown> = {
   /**
    * The name of the function. By default, if you pass in api.foo.bar.baz,
    * it will use "foo/bar:baz" as the name. If you pass in a function handle,
@@ -443,14 +443,14 @@ export type EnqueueOptions = {
   onComplete?: FunctionReference<
     "mutation",
     FunctionVisibility,
-    OnCompleteArgs
+    OnCompleteArgs<Context, ReturnValue>
   > | null;
 
   /**
    * A context object to pass to the `onComplete` mutation.
    * Useful for passing data from the enqueue site to the onComplete site.
    */
-  context?: unknown;
+  context?: Context;
 } & (
   | {
       /**
@@ -513,12 +513,13 @@ function getRetryBehavior(
   return retryOverride ?? (retryByDefault ? defaultRetry : undefined);
 }
 
-async function enqueueArgs(
+async function enqueueArgs<ReturnType>(
   fn:
     | FunctionReference<FunctionType, FunctionVisibility>
     | FunctionHandle<FunctionType, DefaultFunctionArgs>,
   opts:
-    | (EnqueueOptions & Partial<Config> & { retryBehavior?: RetryBehavior })
+    | (EnqueueOptions<ReturnType> &
+        Partial<Config> & { retryBehavior?: RetryBehavior })
     | undefined,
 ) {
   const [fnHandle, fnName] =
@@ -576,7 +577,7 @@ export async function enqueueBatch<
   fnType: FnType,
   fn: FunctionReference<FnType, FunctionVisibility, Args, ReturnType>,
   fnArgsArray: Array<Args>,
-  options: EnqueueOptions & {
+  options: EnqueueOptions<ReturnType> & {
     retryBehavior?: RetryBehavior;
     maxParallelism?: number;
     logLevel?: LogLevel;
@@ -638,7 +639,7 @@ export async function enqueue<
   fnType: FnType,
   fn: FunctionReference<FnType, FunctionVisibility, Args, ReturnType>,
   fnArgs: Args,
-  options: EnqueueOptions & {
+  options: EnqueueOptions<ReturnType> & {
     retryBehavior?: RetryBehavior;
     maxParallelism?: number;
     logLevel?: LogLevel;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -94,9 +94,14 @@ export class Workpool {
    */
   async enqueueAction<Args extends DefaultFunctionArgs, ReturnType, Context>(
     ctx: MutationCtx | ActionCtx,
-    fn: FunctionReference<"action", FunctionVisibility, Args, ReturnType>,
+    fn: FunctionReference<
+      "action",
+      FunctionVisibility,
+      Args,
+      NoInfer<ReturnType>
+    >,
     fnArgs: Args,
-    options?: RetryOption & EnqueueOptions<Context, NoInfer<ReturnType>>,
+    options?: RetryOption & EnqueueOptions<Context, ReturnType>,
   ): Promise<WorkId> {
     const retryBehavior = getRetryBehavior(
       this.options.defaultRetryBehavior,
@@ -128,9 +133,14 @@ export class Workpool {
     Context,
   >(
     ctx: MutationCtx | ActionCtx,
-    fn: FunctionReference<"action", FunctionVisibility, Args, ReturnType>,
+    fn: FunctionReference<
+      "action",
+      FunctionVisibility,
+      Args,
+      NoInfer<ReturnType>
+    >,
     argsArray: Array<Args>,
-    options?: RetryOption & EnqueueOptions<Context, NoInfer<ReturnType>>,
+    options?: RetryOption & EnqueueOptions<Context, ReturnType>,
   ): Promise<WorkId[]> {
     const retryBehavior = getRetryBehavior(
       this.options.defaultRetryBehavior,
@@ -159,9 +169,14 @@ export class Workpool {
    */
   async enqueueMutation<Args extends DefaultFunctionArgs, ReturnType, Context>(
     ctx: MutationCtx | ActionCtx,
-    fn: FunctionReference<"mutation", FunctionVisibility, Args, ReturnType>,
+    fn: FunctionReference<
+      "mutation",
+      FunctionVisibility,
+      Args,
+      NoInfer<ReturnType>
+    >,
     fnArgs: Args,
-    options?: EnqueueOptions<Context, NoInfer<ReturnType>>,
+    options?: EnqueueOptions<Context, ReturnType>,
   ): Promise<WorkId> {
     return enqueue(this.component, ctx, "mutation", fn, fnArgs, {
       ...this.options,
@@ -185,9 +200,14 @@ export class Workpool {
     Context,
   >(
     ctx: MutationCtx | ActionCtx,
-    fn: FunctionReference<"mutation", FunctionVisibility, Args, ReturnType>,
+    fn: FunctionReference<
+      "mutation",
+      FunctionVisibility,
+      Args,
+      NoInfer<ReturnType>
+    >,
     argsArray: Array<Args>,
-    options?: EnqueueOptions<Context, NoInfer<ReturnType>>,
+    options?: EnqueueOptions<Context, ReturnType>,
   ): Promise<WorkId[]> {
     return enqueueBatch(this.component, ctx, "mutation", fn, argsArray, {
       ...this.options,
@@ -209,9 +229,14 @@ export class Workpool {
    */
   async enqueueQuery<Args extends DefaultFunctionArgs, ReturnType, Context>(
     ctx: MutationCtx | ActionCtx,
-    fn: FunctionReference<"query", FunctionVisibility, Args, ReturnType>,
+    fn: FunctionReference<
+      "query",
+      FunctionVisibility,
+      Args,
+      NoInfer<ReturnType>
+    >,
     fnArgs: Args,
-    options?: EnqueueOptions<Context, NoInfer<ReturnType>>,
+    options?: EnqueueOptions<Context, ReturnType>,
   ): Promise<WorkId> {
     return enqueue(this.component, ctx, "query", fn, fnArgs, {
       ...this.options,
@@ -236,9 +261,14 @@ export class Workpool {
     Context,
   >(
     ctx: MutationCtx | ActionCtx,
-    fn: FunctionReference<"query", FunctionVisibility, Args, ReturnType>,
+    fn: FunctionReference<
+      "query",
+      FunctionVisibility,
+      Args,
+      NoInfer<ReturnType>
+    >,
     argsArray: Array<Args>,
-    options?: EnqueueOptions<Context, NoInfer<ReturnType>>,
+    options?: EnqueueOptions<Context, ReturnType>,
   ): Promise<WorkId[]> {
     return enqueueBatch(this.component, ctx, "query", fn, argsArray, {
       ...this.options,
@@ -588,9 +618,9 @@ export async function enqueueBatch<
   component: WorkpoolComponent,
   ctx: MutationCtx | ActionCtx,
   fnType: FnType,
-  fn: FunctionReference<FnType, FunctionVisibility, Args, ReturnType>,
+  fn: FunctionReference<FnType, FunctionVisibility, Args, NoInfer<ReturnType>>,
   fnArgsArray: Array<Args>,
-  options: EnqueueOptions<Context, NoInfer<ReturnType>> & {
+  options: EnqueueOptions<Context, ReturnType> & {
     retryBehavior?: RetryBehavior;
     maxParallelism?: number;
     logLevel?: LogLevel;
@@ -651,9 +681,9 @@ export async function enqueue<
   component: WorkpoolComponent,
   ctx: MutationCtx | ActionCtx,
   fnType: FnType,
-  fn: FunctionReference<FnType, FunctionVisibility, Args, ReturnType>,
+  fn: FunctionReference<FnType, FunctionVisibility, Args, NoInfer<ReturnType>>,
   fnArgs: Args,
-  options: EnqueueOptions<Context, NoInfer<ReturnType>> & {
+  options: EnqueueOptions<Context, ReturnType> & {
     retryBehavior?: RetryBehavior;
     maxParallelism?: number;
     logLevel?: LogLevel;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -30,6 +30,7 @@ import {
   type OnCompleteArgs as SharedOnCompleteArgs,
   type Status,
   vResult,
+  vRunResult,
 } from "../component/shared.js";
 import {
   type ActionCtx,
@@ -45,6 +46,7 @@ export type WorkId = string & { __isWorkId: true };
 export const vWorkId = v.string() as VString<WorkId>;
 export {
   vResult,
+  vRunResult,
   DEFAULT_RETRY_BEHAVIOR,
   /** @deprecated Use `vResult` instead. */
   vResult as resultValidator,
@@ -313,9 +315,11 @@ export class Workpool {
   defineOnComplete<
     DataModel extends GenericDataModel,
     V extends Validator<any, any, any> = VAny<any, "optional">,
+    RV extends Validator<any, any, any> = VAny<any, "optional">,
   >({
     context,
     handler,
+    returnValue,
   }: {
     context?: V;
     handler: (
@@ -323,12 +327,17 @@ export class Workpool {
       args: {
         workId: WorkId;
         context: Infer<V>;
-        result: RunResult;
+        result: RunResult<Infer<RV>>;
       },
     ) => Promise<void>;
-  }): RegisteredMutation<"internal", OnCompleteArgs, null> {
+    returnValue?: RV;
+  }): RegisteredMutation<
+    "internal",
+    OnCompleteArgs<Infer<V>, Infer<RV>>,
+    null
+  > {
     return internalMutationGeneric({
-      args: vOnCompleteArgs(context),
+      args: vOnCompleteArgs(context, returnValue),
       handler,
     });
   }
@@ -350,11 +359,12 @@ export class Workpool {
  */
 export function vOnCompleteArgs<
   V extends Validator<any, "required", any> = VAny,
->(context?: V) {
+  RV extends Validator<any, "required", any> = VAny,
+>(context?: V, runResult?: RV) {
   return v.object({
     workId: vWorkId,
     context: (context ?? v.optional(v.any())) as V,
-    result: vResult,
+    result: vRunResult(runResult ?? v.optional(v.any())),
   });
 }
 
@@ -464,7 +474,7 @@ export type EnqueueOptions = {
     }
 );
 
-export type OnCompleteArgs = {
+export type OnCompleteArgs<Context = unknown, Returns = unknown> = {
   /**
    * The ID of the work that completed.
    */
@@ -473,11 +483,11 @@ export type OnCompleteArgs = {
    * The context object passed when enqueuing the work.
    * Useful for passing data from the enqueue site to the onComplete site.
    */
-  context: unknown;
+  context: Context;
   /**
    * The result of the run that completed.
    */
-  result: RunResult;
+  result: RunResult<Returns>;
 };
 
 // ensure OnCompleteArgs satisfies SharedOnCompleteArgs

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -92,11 +92,11 @@ export class Workpool {
    *   onComplete handling, and scheduling via `runAt` or `runAfter`.
    * @returns The ID of the work that was enqueued.
    */
-  async enqueueAction<Args extends DefaultFunctionArgs, ReturnType>(
+  async enqueueAction<Args extends DefaultFunctionArgs, ReturnType, Context>(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"action", FunctionVisibility, Args, ReturnType>,
     fnArgs: Args,
-    options?: RetryOption & EnqueueOptions<ReturnType>,
+    options?: RetryOption & EnqueueOptions<Context, NoInfer<ReturnType>>,
   ): Promise<WorkId> {
     const retryBehavior = getRetryBehavior(
       this.options.defaultRetryBehavior,
@@ -122,11 +122,15 @@ export class Workpool {
    *   onComplete handling, and scheduling via `runAt` or `runAfter`.
    * @returns The IDs of the work that was enqueued.
    */
-  async enqueueActionBatch<Args extends DefaultFunctionArgs, ReturnType>(
+  async enqueueActionBatch<
+    Args extends DefaultFunctionArgs,
+    ReturnType,
+    Context,
+  >(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"action", FunctionVisibility, Args, ReturnType>,
     argsArray: Array<Args>,
-    options?: RetryOption & EnqueueOptions<ReturnType>,
+    options?: RetryOption & EnqueueOptions<Context, NoInfer<ReturnType>>,
   ): Promise<WorkId[]> {
     const retryBehavior = getRetryBehavior(
       this.options.defaultRetryBehavior,
@@ -153,11 +157,11 @@ export class Workpool {
    * @param options - The options for the mutation to specify onComplete handling
    *   and scheduling via `runAt` or `runAfter`.
    */
-  async enqueueMutation<Args extends DefaultFunctionArgs, ReturnType>(
+  async enqueueMutation<Args extends DefaultFunctionArgs, ReturnType, Context>(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"mutation", FunctionVisibility, Args, ReturnType>,
     fnArgs: Args,
-    options?: EnqueueOptions<ReturnType>,
+    options?: EnqueueOptions<Context, NoInfer<ReturnType>>,
   ): Promise<WorkId> {
     return enqueue(this.component, ctx, "mutation", fn, fnArgs, {
       ...this.options,
@@ -175,11 +179,15 @@ export class Workpool {
    * @param options - The options for the mutations to specify onComplete handling
    *   and scheduling via `runAt` or `runAfter`.
    */
-  async enqueueMutationBatch<Args extends DefaultFunctionArgs, ReturnType>(
+  async enqueueMutationBatch<
+    Args extends DefaultFunctionArgs,
+    ReturnType,
+    Context,
+  >(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"mutation", FunctionVisibility, Args, ReturnType>,
     argsArray: Array<Args>,
-    options?: EnqueueOptions<ReturnType>,
+    options?: EnqueueOptions<Context, NoInfer<ReturnType>>,
   ): Promise<WorkId[]> {
     return enqueueBatch(this.component, ctx, "mutation", fn, argsArray, {
       ...this.options,
@@ -199,11 +207,11 @@ export class Workpool {
    * @param options - The options for the query to specify onComplete handling
    *   and scheduling via `runAt` or `runAfter`.
    */
-  async enqueueQuery<Args extends DefaultFunctionArgs, ReturnType>(
+  async enqueueQuery<Args extends DefaultFunctionArgs, ReturnType, Context>(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"query", FunctionVisibility, Args, ReturnType>,
     fnArgs: Args,
-    options?: EnqueueOptions<ReturnType>,
+    options?: EnqueueOptions<Context, NoInfer<ReturnType>>,
   ): Promise<WorkId> {
     return enqueue(this.component, ctx, "query", fn, fnArgs, {
       ...this.options,
@@ -222,11 +230,15 @@ export class Workpool {
    * @param options - The options for the queries to specify onComplete handling
    *   and scheduling via `runAt` or `runAfter`.
    */
-  async enqueueQueryBatch<Args extends DefaultFunctionArgs, ReturnType>(
+  async enqueueQueryBatch<
+    Args extends DefaultFunctionArgs,
+    ReturnType,
+    Context,
+  >(
     ctx: MutationCtx | ActionCtx,
     fn: FunctionReference<"query", FunctionVisibility, Args, ReturnType>,
     argsArray: Array<Args>,
-    options?: EnqueueOptions<ReturnType>,
+    options?: EnqueueOptions<Context, NoInfer<ReturnType>>,
   ): Promise<WorkId[]> {
     return enqueueBatch(this.component, ctx, "query", fn, argsArray, {
       ...this.options,
@@ -410,7 +422,7 @@ export type WorkpoolRetryOptions = {
   retryActionsByDefault?: boolean;
 };
 
-export type EnqueueOptions<ReturnValue, Context = unknown> = {
+export type EnqueueOptions<Context, ReturnValue> = {
   /**
    * The name of the function. By default, if you pass in api.foo.bar.baz,
    * it will use "foo/bar:baz" as the name. If you pass in a function handle,
@@ -513,12 +525,12 @@ function getRetryBehavior(
   return retryOverride ?? (retryByDefault ? defaultRetry : undefined);
 }
 
-async function enqueueArgs<ReturnType>(
+async function enqueueArgs<Context, ReturnType>(
   fn:
     | FunctionReference<FunctionType, FunctionVisibility>
     | FunctionHandle<FunctionType, DefaultFunctionArgs>,
   opts:
-    | (EnqueueOptions<ReturnType> &
+    | (EnqueueOptions<Context, ReturnType> &
         Partial<Config> & { retryBehavior?: RetryBehavior })
     | undefined,
 ) {
@@ -571,13 +583,14 @@ export async function enqueueBatch<
   FnType extends FunctionType,
   Args extends DefaultFunctionArgs,
   ReturnType,
+  Context,
 >(
   component: WorkpoolComponent,
   ctx: MutationCtx | ActionCtx,
   fnType: FnType,
   fn: FunctionReference<FnType, FunctionVisibility, Args, ReturnType>,
   fnArgsArray: Array<Args>,
-  options: EnqueueOptions<ReturnType> & {
+  options: EnqueueOptions<Context, NoInfer<ReturnType>> & {
     retryBehavior?: RetryBehavior;
     maxParallelism?: number;
     logLevel?: LogLevel;
@@ -633,13 +646,14 @@ export async function enqueue<
   FnType extends FunctionType,
   Args extends DefaultFunctionArgs,
   ReturnType,
+  Context,
 >(
   component: WorkpoolComponent,
   ctx: MutationCtx | ActionCtx,
   fnType: FnType,
   fn: FunctionReference<FnType, FunctionVisibility, Args, ReturnType>,
   fnArgs: Args,
-  options: EnqueueOptions<ReturnType> & {
+  options: EnqueueOptions<Context, NoInfer<ReturnType>> & {
     retryBehavior?: RetryBehavior;
     maxParallelism?: number;
     logLevel?: LogLevel;

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -72,7 +72,7 @@ export const DEFAULT_RETRY_BEHAVIOR: RetryBehavior = {
 // This ensures that the type satisfies the schema.
 const _ = {} as RetryBehavior satisfies Infer<typeof retryBehavior>;
 
-export const vResult = vRunResult(v.optional(v.any()));
+export const vResult = vRunResult(v.any());
 export function vRunResult<RV extends Validator<any, any, any> = VAny>(
   returnValue: RV,
 ) {

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -1,4 +1,4 @@
-import type { Infer } from "convex/values";
+import type { Infer, Validator, VAny } from "convex/values";
 
 import { v } from "convex/values";
 import { type Logger, logLevel } from "./logging.js";
@@ -72,20 +72,42 @@ export const DEFAULT_RETRY_BEHAVIOR: RetryBehavior = {
 // This ensures that the type satisfies the schema.
 const _ = {} as RetryBehavior satisfies Infer<typeof retryBehavior>;
 
-export const vResult = v.union(
-  v.object({
-    kind: v.literal("success"),
-    returnValue: v.any(),
-  }),
-  v.object({
-    kind: v.literal("failed"),
-    error: v.string(),
-  }),
-  v.object({
-    kind: v.literal("canceled"),
-  }),
-);
-export type RunResult = Infer<typeof vResult>;
+export const vResult = vRunResult(v.optional(v.any()));
+export function vRunResult<RV extends Validator<any, any, any> = VAny>(
+  returnValue: RV,
+) {
+  return v.union(
+    v.object({
+      kind: v.literal("success"),
+      returnValue,
+    }),
+    v.object({
+      kind: v.literal("failed"),
+      error: v.string(),
+    }),
+    v.object({
+      kind: v.literal("canceled"),
+    }),
+  );
+}
+export type RunResult<Returns = unknown> =
+  | {
+      kind: "success";
+      /**
+       * The return value of the run, if it succeeded.
+       */
+      returnValue?: Returns;
+    }
+  | {
+      kind: "failed";
+      /**
+       * The error message of the run, if it failed.
+       */
+      error: string;
+    }
+  | {
+      kind: "canceled";
+    };
 
 export const vOnCompleteFnContext = v.object({
   fnHandle: v.string(), // mutation


### PR DESCRIPTION
add vRunResult with generic return value

enforce return type & context types on workpool enqueue

fn return value is contravariant with onComplete expected returnValue arg