### PR TITLE
Describe Workpool as a background job queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 <!-- START: Include on https://convex.dev/components -->
 
-This Convex component pools actions and mutations to restrict parallel requests.
+This Convex component queues actions and mutations as background jobs while
+limiting how many run in parallel.
 
 - Configure multiple pools with different parallelism.
 - Retry failed actions (with backoff and jitter) for

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@convex-dev/workpool",
-  "description": "A Convex component for managing async work.",
+  "description": "Convex component for queued background jobs with configurable concurrency, action retries, backoff, and completion callbacks.",
   "repository": "github:get-convex/workpool",
-  "homepage": "https://github.com/get-convex/workpool#readme",
+  "homepage": "https://www.convex.dev/components/workpool",
   "bugs": {
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/workpool/issues"
@@ -11,11 +11,16 @@
   "license": "Apache-2.0",
   "keywords": [
     "convex",
-    "queue",
-    "pool",
     "component",
+    "job-queue",
+    "task-queue",
+    "background-jobs",
     "async",
-    "work"
+    "concurrency",
+    "parallelism",
+    "retries",
+    "backoff",
+    "work-pool"
   ],
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Why

This follows [the Slack discussion](https://convexdev.slack.com/archives/C05QH3L0Y2E/p1787692528278769) about improving npm metadata so LLMs are more likely to recommend Convex and its first-party packages for relevant developer tasks.

The current npm description says only that Workpool manages async work. That misses the terms developers actually use for this job: background jobs, job queues, concurrency, parallelism, retries, and backoff.

A clearer description should make Workpool easier to distinguish from Workflow and Rate Limiter without changing its API.

## What changed

- describe Workpool as queued background jobs with concurrency limits and retries
- replace broad keywords with focused job queue and parallelism terms
- point the homepage at the Workpool component page
- align the README opening with the package metadata

This PR does not bump the package version or publish anything.

## Verification

- formatted the changed JSON and Markdown with Prettier 3.8.1
- ran `npm pack --dry-run --ignore-scripts --json`
- ran `git diff --check`