### PR TITLE
bump batch-worker & longer cooldown when saturated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Bump Batch Worker dependency to prevent OCC conflicts on enqueue.
+- Keeps the Batch Worker running for a 10-second cooldown while Workpool is
+  saturated, reducing enqueue retries with worker status transitions.
 
 ## 0.4.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Bump Batch Worker dependency to prevent OCC conflicts on enqueue.
+
 ## 0.4.10
 
 - Adds `vRunResult` and type-safety for passing onComplete handlers with return

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as test_scenarios_bigArgs from "../test/scenarios/bigArgs.js";
 import type * as test_scenarios_bigContext from "../test/scenarios/bigContext.js";
 import type * as test_scenarios_bigReturnTypes from "../test/scenarios/bigReturnTypes.js";
 import type * as test_scenarios_burstyBatches from "../test/scenarios/burstyBatches.js";
+import type * as test_scenarios_enqueueOcc from "../test/scenarios/enqueueOcc.js";
 import type * as test_scenarios_noisyNeighbor from "../test/scenarios/noisyNeighbor.js";
 import type * as test_scenarios_overhead from "../test/scenarios/overhead.js";
 import type * as test_scenarios_sustained from "../test/scenarios/sustained.js";
@@ -45,6 +46,7 @@ declare const fullApi: ApiFromModules<{
   "test/scenarios/bigContext": typeof test_scenarios_bigContext;
   "test/scenarios/bigReturnTypes": typeof test_scenarios_bigReturnTypes;
   "test/scenarios/burstyBatches": typeof test_scenarios_burstyBatches;
+  "test/scenarios/enqueueOcc": typeof test_scenarios_enqueueOcc;
   "test/scenarios/noisyNeighbor": typeof test_scenarios_noisyNeighbor;
   "test/scenarios/overhead": typeof test_scenarios_overhead;
   "test/scenarios/sustained": typeof test_scenarios_sustained;

--- a/example/convex/test/scenarios/enqueueOcc.ts
+++ b/example/convex/test/scenarios/enqueueOcc.ts
@@ -1,0 +1,303 @@
+import { type WorkId, Workpool, vWorkId } from "@convex-dev/workpool";
+import { v } from "convex/values";
+import { components, internal } from "../../_generated/api";
+import { internalAction, internalMutation } from "../../_generated/server";
+
+const pool = new Workpool(components.testWorkpool, {
+  maxParallelism: 1,
+  logLevel: "WARN",
+});
+
+export const blocker = internalAction({
+  args: { durationMs: v.number() },
+  returns: v.null(),
+  handler: async (_ctx, { durationMs }) => {
+    if (
+      !Number.isFinite(durationMs) ||
+      durationMs < 1_000 ||
+      durationMs > 120_000
+    ) {
+      throw new Error("durationMs must be between 1,000 and 120,000");
+    }
+    await new Promise((resolve) => setTimeout(resolve, durationMs));
+    return null;
+  },
+});
+
+export const queuedMutation = internalMutation({
+  args: { payload: v.string() },
+  returns: v.null(),
+  handler: async (_ctx, _args) => null,
+});
+
+/**
+ * Hold the root mutation open after Workpool's nested enqueue. In the
+ * vulnerable implementation, that enqueue read Batch Worker's `workers`
+ * document and this widened the interval in which the scheduled loop could
+ * invalidate it. The saturation-aware implementation skips that read.
+ */
+export const slowEnqueue = internalMutation({
+  args: {
+    payload: v.string(),
+    spinIterations: v.number(),
+  },
+  returns: vWorkId,
+  handler: async (ctx, { payload, spinIterations }): Promise<WorkId> => {
+    if (
+      !Number.isInteger(spinIterations) ||
+      spinIterations < 0 ||
+      spinIterations > 50_000_000
+    ) {
+      throw new Error("spinIterations must be an integer from 0 to 50,000,000");
+    }
+    if (payload.length > 500_000) {
+      throw new Error("payload must be at most 500,000 characters");
+    }
+
+    const workId: WorkId = await pool.enqueueMutation(
+      ctx,
+      internal.test.scenarios.enqueueOcc.queuedMutation,
+      { payload },
+    );
+
+    // A deterministic CPU delay after enqueue. Keeping the checksum live
+    // prevents the loop from being optimized away.
+    let checksum = 0;
+    for (let i = 0; i < spinIterations; i++) {
+      checksum = (checksum + i) | 0;
+    }
+    if (checksum === Number.MAX_SAFE_INTEGER) {
+      throw new Error("unreachable checksum");
+    }
+    return workId;
+  },
+});
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(
+    sorted.length - 1,
+    Math.ceil((p / 100) * sorted.length) - 1,
+  );
+  return sorted[Math.max(0, index)];
+}
+
+/**
+ * Sustained-load variant: keep `concurrency` enqueues in flight for
+ * `durationMs` against a saturated pool. Unlike the one-shot burst below,
+ * this spans many status-cooldown periods, so it can detect how often the
+ * loop's idle/running transitions invalidate in-flight enqueues (as retry
+ * latency inflation and, at the extreme, exhausted-retry failures).
+ */
+export const storm = internalAction({
+  args: {
+    durationMs: v.optional(v.number()),
+    concurrency: v.optional(v.number()),
+    payloadBytes: v.optional(v.number()),
+    spinIterations: v.optional(v.number()),
+    blockerMs: v.optional(v.number()),
+  },
+  returns: v.object({
+    attempted: v.number(),
+    blockerStarted: v.boolean(),
+    succeeded: v.number(),
+    failed: v.number(),
+    workersFailures: v.number(),
+    workerStateFailures: v.number(),
+    otherFailures: v.number(),
+    p50Ms: v.number(),
+    p95Ms: v.number(),
+    p99Ms: v.number(),
+    maxMs: v.number(),
+    errors: v.array(v.string()),
+  }),
+  handler: async (
+    ctx,
+    {
+      durationMs = 30_000,
+      concurrency = 32,
+      payloadBytes = 10_000,
+      spinIterations = 10_000_000,
+      blockerMs = 60_000,
+    },
+  ) => {
+    if (!Number.isInteger(durationMs) || durationMs < 1_000 || durationMs > 120_000) {
+      throw new Error("durationMs must be an integer from 1,000 to 120,000");
+    }
+    if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 100) {
+      throw new Error("concurrency must be an integer from 1 to 100");
+    }
+    if (!Number.isInteger(payloadBytes) || payloadBytes < 0 || payloadBytes > 500_000) {
+      throw new Error("payloadBytes must be an integer from 0 to 500,000");
+    }
+
+    const blockerId = await pool.enqueueAction(
+      ctx,
+      internal.test.scenarios.enqueueOcc.blocker,
+      { durationMs: blockerMs },
+    );
+    let blockerRunning = false;
+    const startDeadline = Date.now() + 10_000;
+    while (Date.now() < startDeadline) {
+      const status = await ctx.runQuery(components.testWorkpool.lib.status, {
+        id: blockerId,
+      });
+      if (status.state === "running") {
+        blockerRunning = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    // Let the post-start cooldown expire so the storm begins in the
+    // steady-state saturated regime rather than riding the startup window.
+    await new Promise((resolve) => setTimeout(resolve, 2_500));
+
+    const payload = "x".repeat(payloadBytes);
+    const deadline = Date.now() + durationMs;
+    const successLatencies: number[] = [];
+    const errors: string[] = [];
+    await Promise.all(
+      Array.from({ length: concurrency }, async () => {
+        while (Date.now() < deadline) {
+          const start = Date.now();
+          try {
+            await ctx.runMutation(
+              internal.test.scenarios.enqueueOcc.slowEnqueue,
+              { payload, spinIterations },
+            );
+            successLatencies.push(Date.now() - start);
+          } catch (error) {
+            errors.push(String(error));
+          }
+        }
+      }),
+    );
+
+    const workersFailures = errors.filter((error) =>
+      error.includes('"workers" table'),
+    ).length;
+    const workerStateFailures = errors.filter((error) =>
+      error.includes('"workerState" table'),
+    ).length;
+    successLatencies.sort((a, b) => a - b);
+    return {
+      attempted: successLatencies.length + errors.length,
+      blockerStarted: blockerRunning,
+      succeeded: successLatencies.length,
+      failed: errors.length,
+      workersFailures,
+      workerStateFailures,
+      otherFailures: errors.length - workersFailures - workerStateFailures,
+      p50Ms: percentile(successLatencies, 50),
+      p95Ms: percentile(successLatencies, 95),
+      p99Ms: percentile(successLatencies, 99),
+      maxMs: successLatencies[successLatencies.length - 1] ?? 0,
+      errors: errors.slice(0, 5),
+    };
+  },
+});
+
+type RunResult = {
+  attempted: number;
+  blockerStarted: boolean;
+  succeeded: number;
+  failed: number;
+  workersFailures: number;
+  workerStateFailures: number;
+  otherFailures: number;
+  errors: string[];
+};
+
+export default internalAction({
+  args: {
+    count: v.optional(v.number()),
+    payloadBytes: v.optional(v.number()),
+    spinIterations: v.optional(v.number()),
+    blockerMs: v.optional(v.number()),
+  },
+  returns: v.object({
+    attempted: v.number(),
+    blockerStarted: v.boolean(),
+    succeeded: v.number(),
+    failed: v.number(),
+    workersFailures: v.number(),
+    workerStateFailures: v.number(),
+    otherFailures: v.number(),
+    errors: v.array(v.string()),
+  }),
+  handler: async (
+    ctx,
+    {
+      count = 100,
+      payloadBytes = 100_000,
+      spinIterations = 10_000_000,
+      blockerMs = 30_000,
+    },
+  ): Promise<RunResult> => {
+    if (!Number.isInteger(count) || count < 1 || count > 500) {
+      throw new Error("count must be an integer from 1 to 500");
+    }
+    if (
+      !Number.isInteger(payloadBytes) ||
+      payloadBytes < 0 ||
+      payloadBytes > 500_000
+    ) {
+      throw new Error("payloadBytes must be an integer from 0 to 500,000");
+    }
+
+    const blockerId = await pool.enqueueAction(
+      ctx,
+      internal.test.scenarios.enqueueOcc.blocker,
+      { durationMs: blockerMs },
+    );
+
+    let blockerRunning = false;
+    const startDeadline = Date.now() + 10_000;
+    while (Date.now() < startDeadline) {
+      const status = await ctx.runQuery(components.testWorkpool.lib.status, {
+        id: blockerId,
+      });
+      if (status.state === "running") {
+        blockerRunning = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    // Wait past the normal two-second cooldown. A saturated pool now uses ten
+    // seconds, so workers.status should still be "running" during the burst.
+    await new Promise((resolve) => setTimeout(resolve, 2_500));
+
+    const payload = "x".repeat(payloadBytes);
+    const settled: PromiseSettledResult<WorkId>[] = await Promise.allSettled(
+      Array.from({ length: count }, () =>
+        ctx.runMutation(internal.test.scenarios.enqueueOcc.slowEnqueue, {
+          payload,
+          spinIterations,
+        }),
+      ),
+    );
+    const errors: string[] = settled
+      .filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      )
+      .map((result) => String(result.reason));
+    const workersFailures = errors.filter((error) =>
+      error.includes('"workers" table'),
+    ).length;
+    const workerStateFailures = errors.filter((error) =>
+      error.includes('"workerState" table'),
+    ).length;
+
+    return {
+      attempted: count,
+      blockerStarted: blockerRunning,
+      succeeded: count - errors.length,
+      failed: errors.length,
+      workersFailures,
+      workerStateFailures,
+      otherFailures: errors.length - workersFailures - workerStateFailures,
+      errors: errors.slice(0, 10),
+    };
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@convex-dev/batch-worker": "^0.2.1"
+        "@convex-dev/batch-worker": "^0.2.2"
       },
       "devDependencies": {
         "@convex-dev/eslint-plugin": "^4.0.0",
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@convex-dev/batch-worker": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@convex-dev/batch-worker/-/batch-worker-0.2.1.tgz",
-      "integrity": "sha512-QEDW6XmT+SmBJAmNqyl0QAEmJ4yMKJAIoJ+LntsA8KY5gYP+UhSFvTEMCvo177RZxOR/cfkZ3R+4S/UBaj/JnQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@convex-dev/batch-worker/-/batch-worker-0.2.2.tgz",
+      "integrity": "sha512-3knigElzTVhWw1sN28EYkGBTdrJZ03vMj2PJPuFq3V0Tg41i7tcv/EWDBFQWcUaKzBWWVw693hcJtxCF3CRtEw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "convex": "^1.36.1",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
   "types": "./dist/client/index.d.ts",
   "module": "./dist/client/index.js",
   "dependencies": {
-    "@convex-dev/batch-worker": "^0.2.1"
+    "@convex-dev/batch-worker": "^0.2.2"
   }
 }

--- a/src/component/README.md
+++ b/src/component/README.md
@@ -47,10 +47,10 @@ The loop lifecycle is owned by `@convex-dev/batch-worker`. Workpool provides a
 state, generation checks, cooldown polling, timeout wakeups, and monitor-based
 restart if the loop dies.
 
-Workpool still avoids unproductive enqueue wakeups while saturated: if
-`internalState.running.length >= maxParallelism`, enqueue skips `ping`. Sources
-that can free capacity or change existing work (`complete`, `retry`, `cancel`,
-manual kicks, and maxParallelism increases) still ping.
+When the pool is saturated (`running.length >= maxParallelism`), `getBatch` uses
+a 10-second idle cooldown instead of the normal 2 seconds. This keeps
+batch-worker's status `running` for longer at full throttle, so most enqueue
+pings are no-ops rather than racing an idle transition.
 
 ## Retention optimization strategy
 

--- a/src/component/loop.test.ts
+++ b/src/component/loop.test.ts
@@ -10,7 +10,11 @@ import {
 } from "vitest";
 import { api, components, internal } from "./_generated/api.js";
 import type { Doc, Id } from "./_generated/dataModel.js";
-import { RECOVERY_PERIOD_SEGMENTS } from "./loop.js";
+import {
+  RECOVERY_PERIOD_SEGMENTS,
+  SATURATED_STATUS_COOLDOWN,
+  STATUS_COOLDOWN,
+} from "./loop.js";
 import { setupTest } from "./setup.test.js";
 import {
   DEFAULT_MAX_PARALLELISM,
@@ -487,7 +491,32 @@ describe("loop", () => {
       // Nothing running and no future work → no wake-up hint.
       if (result.kind === "idle") {
         expect(result.timeoutMs).toBeUndefined();
+        expect(result.cooldownMs).toBe(STATUS_COOLDOWN);
       }
+    });
+
+    it("uses a longer idle cooldown while saturated", async () => {
+      await initialize({ maxParallelism: 1 });
+      await enqueueWork();
+      await runLoop();
+
+      const result = await t.query(internal.loop.getBatch, {
+        name: WORKER_NAME,
+      });
+      assert(result.kind === "idle");
+      expect(result.cooldownMs).toBe(SATURATED_STATUS_COOLDOWN);
+    });
+
+    it("uses the normal idle cooldown while capacity remains", async () => {
+      await initialize({ maxParallelism: 2 });
+      await enqueueWork();
+      await runLoop();
+
+      const result = await t.query(internal.loop.getBatch, {
+        name: WORKER_NAME,
+      });
+      assert(result.kind === "idle");
+      expect(result.cooldownMs).toBe(STATUS_COOLDOWN);
     });
 
     it("returns a work batch when a pending start is ready", async () => {

--- a/src/component/loop.ts
+++ b/src/component/loop.ts
@@ -44,6 +44,9 @@ export const RECOVERY_PERIOD_SEGMENTS = toSegment(1 * MINUTE); // how often to c
 // status, re-polling this often during that window — preserving the old loop's
 // cooldown behavior, now expressed via batch-worker's idle hints.
 export const STATUS_COOLDOWN = 2 * SECOND;
+// At full capacity, keep batch-worker's status stable longer so enqueue pings
+// generally observe `running` and no-op instead of racing an idle transition.
+export const SATURATED_STATUS_COOLDOWN = 10 * SECOND;
 export const COOLDOWN_CHECK_INTERVAL = 200;
 // Buffer applied when querying with cursors. Transactions that started
 // before ours may still be running and commit inserts at segments behind
@@ -212,7 +215,10 @@ export const getBatch = internalQuery({
     // future-scheduled work and the periodic recovery scan.
     return {
       kind: "idle" as const,
-      cooldownMs: STATUS_COOLDOWN,
+      cooldownMs:
+        running.length >= globals.maxParallelism
+          ? SATURATED_STATUS_COOLDOWN
+          : STATUS_COOLDOWN,
       pollIntervalMs: COOLDOWN_CHECK_INTERVAL,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     };


### PR DESCRIPTION
fix: bump batch-worker to ^0.2.2 to avoid enqueue OCC conflicts

batch-worker 0.2.2 advances lastWorkTs when waking an idle worker, so a
woken loop polls through a full cooldown instead of flipping status
running -> idle on every enqueue ping. Under a saturated pool this
eliminates the workers/workerState OCC failures on concurrent enqueues.

perf: hold batch-worker status running for 10s while saturated

At full capacity, getBatch now returns a 10-second idle cooldown instead
of the normal 2 seconds. Status transitions on the workers table become
~5x rarer under sustained enqueue traffic, so fewer in-flight enqueues
race an idle flip and retry; live storm testing showed a p99 enqueue
latency improvement with no change at p50.

test: add enqueueOcc burst and storm load scenarios

Live-deployment scenarios that reproduce the workers/workerState OCC
failures on concurrent enqueues against a saturated pool: a one-shot
burst of 100 concurrent enqueues, and a sustained storm that keeps N
enqueues in flight for a duration and reports failure counts by table
plus enqueue latency percentiles.