### PR TITLE
bound the incoming cursor by the snapshot timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,16 +23,16 @@
 - A batch enqueue packs entries sharing a start time into one `pendingStart`
   document (up to 256), so it writes a few documents rather than hundreds;
   starting or canceling an entry patches it out of its document.
-- The loop reads at a snapshot timestamp (`ctx.meta.getSnapshotTs()`), which is
-  both its eligibility bound and its cursor's limit. A ready entry's commit
-  stamp is at or below the snapshot, so it's eligible as soon as it's visible; a
-  scheduled entry is due once the commit clock passes its start time; and since
-  nothing committing later is stamped at or below the snapshot, the cursor can
-  rest on the last key it handled. Every key written — enqueue, retry, or re-key
-  — is raised to at least its writer's snapshot, so nothing is ever keyed below
-  what was already visible when it was written. The design makes no assumptions
-  about how wall clocks relate to the commit timestamp clock — skew between them
-  only shifts when scheduled work and retries are considered due.
+- The loop reads at a snapshot timestamp (`ctx.meta.getSnapshotTs()`) and its
+  cursor never passes it: nothing committing later is stamped at or below the
+  snapshot, so a scheduled entry starting at its wall-clock time can't push the
+  cursor ahead of a racing enqueue's commit. Work is eligible up to the later of
+  the snapshot and the wall clock, so ready work starts as soon as it's visible
+  and scheduled work as soon as either clock says it's due. Every key written —
+  enqueue, retry, or re-key — is raised to at least its writer's snapshot, so
+  nothing is ever keyed below what was already visible when it was written. The
+  design makes no assumptions about how wall clocks relate to the commit
+  timestamp clock.
 - Upgrading in place is safe, including for work that hasn't come due yet. A
   `pendingStart` an older version wrote holds a 100ms bucket — eight orders of
   magnitude below a nanosecond timestamp — so the loop recognizes it, reads the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,11 @@
   stamp is at or below the snapshot, so it's eligible as soon as it's visible; a
   scheduled entry is due once the commit clock passes its start time; and since
   nothing committing later is stamped at or below the snapshot, the cursor can
-  rest on the last key it handled. The design makes no assumptions about how
-  wall clocks relate to the commit timestamp clock — skew between them only
-  shifts when scheduled work and retries are considered due.
+  rest on the last key it handled. Every key written — enqueue, retry, or re-key
+  — is raised to at least its writer's snapshot, so nothing is ever keyed below
+  what was already visible when it was written. The design makes no assumptions
+  about how wall clocks relate to the commit timestamp clock — skew between them
+  only shifts when scheduled work and retries are considered due.
 - Upgrading in place is safe, including for work that hasn't come due yet. A
   `pendingStart` an older version wrote holds a 100ms bucket — eight orders of
   magnitude below a nanosecond timestamp — so the loop recognizes it, reads the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,16 +23,15 @@
 - A batch enqueue packs entries sharing a start time into one `pendingStart`
   document (up to 256), so it writes a few documents rather than hundreds;
   starting or canceling an entry patches it out of its document.
-- The loop reads at a snapshot timestamp (`ctx.meta.getSnapshotTs()`) and its
-  cursor never passes it: nothing committing later is stamped at or below the
-  snapshot, so a scheduled entry starting at its wall-clock time can't push the
-  cursor ahead of a racing enqueue's commit. Work is eligible up to the later of
-  the snapshot and the wall clock, so ready work starts as soon as it's visible
-  and scheduled work as soon as either clock says it's due. Every key written —
-  enqueue, retry, or re-key — is raised to at least its writer's snapshot, so
-  nothing is ever keyed below what was already visible when it was written. The
-  design makes no assumptions about how wall clocks relate to the commit
-  timestamp clock.
+- The loop reads at a snapshot timestamp and its cursor never passes it: nothing
+  committing later is stamped at or below the snapshot, so a scheduled entry
+  starting at its wall-clock time can't push the cursor ahead of a racing
+  enqueue's commit. Work is eligible up to the later of the snapshot and the
+  wall clock, so ready work starts as soon as it's visible and scheduled work as
+  soon as either clock says it's due. Every key written — enqueue, retry, or
+  re-key — is raised to at least its writer's snapshot, so nothing is ever keyed
+  below what was already visible when it was written. The design makes no
+  assumptions about how wall clocks relate to the commit timestamp clock.
 - Upgrading in place is safe, including for work that hasn't come due yet. A
   `pendingStart` an older version wrote holds a 100ms bucket — eight orders of
   magnitude below a nanosecond timestamp — so the loop recognizes it, reads the
@@ -47,11 +46,9 @@
   starts, `status` reports it as `"pending"` — even if it's mid-attempt (queued
   is the longer-lived of the two states it could be in) — and canceling it takes
   effect immediately but only clears its queue entry when that entry comes due.
-- This change is not backwards compatible. It requires a `convex` release with
-  `ctx.meta.getSnapshotTs()` (TODO: pin the version once it ships), and
-  downgrading a workpool that has run this version is not supported: an older
-  version would read a nanosecond timestamp as a 100ms bucket far in the future
-  and never start the work.
+- This change is not backwards compatible. Downgrading a workpool that has run
+  this version is not supported: an older version would read a nanosecond
+  timestamp as a 100ms bucket far in the future and never start the work.
 
 ## 0.4.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@
 - A batch enqueue packs entries sharing a start time into one `pendingStart`
   document (up to 256), so it writes a few documents rather than hundreds;
   starting or canceling an entry patches it out of its document.
-- The loop's cursor never advances past the snapshot timestamp its iteration
-  read at (`ctx.meta.getSnapshotTs()`): nothing that commits later is stamped at
-  or below it, so a scheduled entry starting at its wall-clock time can't push
-  the cursor ahead of a racing enqueue's commit — the design makes no
-  assumptions about how wall clocks relate to the commit timestamp clock.
+- The loop reads at a snapshot timestamp (`ctx.meta.getSnapshotTs()`), which is
+  both its eligibility bound and its cursor's limit. A ready entry's commit
+  stamp is at or below the snapshot, so it's eligible as soon as it's visible; a
+  scheduled entry is due once the commit clock passes its start time; and since
+  nothing committing later is stamped at or below the snapshot, the cursor can
+  rest on the last key it handled. The design makes no assumptions about how
+  wall clocks relate to the commit timestamp clock — skew between them only
+  shifts when scheduled work and retries are considered due.
 - Upgrading in place is safe, including for work that hasn't come due yet. A
   `pendingStart` an older version wrote holds a 100ms bucket — eight orders of
   magnitude below a nanosecond timestamp — so the loop recognizes it, reads the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,11 @@
 - A batch enqueue packs entries sharing a start time into one `pendingStart`
   document (up to 256), so it writes a few documents rather than hundreds;
   starting or canceling an entry patches it out of its document.
-- The loop's cursor never advances past the newest commit timestamp it has
-  observed, so a scheduled entry starting at its wall-clock time can't push the
-  cursor ahead of a racing enqueue's commit — the design makes no assumptions
-  about how wall clocks relate to the commit timestamp clock.
+- The loop's cursor never advances past the snapshot timestamp its iteration
+  read at (`ctx.meta.getSnapshotTs()`): nothing that commits later is stamped at
+  or below it, so a scheduled entry starting at its wall-clock time can't push
+  the cursor ahead of a racing enqueue's commit — the design makes no
+  assumptions about how wall clocks relate to the commit timestamp clock.
 - Upgrading in place is safe, including for work that hasn't come due yet. A
   `pendingStart` an older version wrote holds a 100ms bucket — eight orders of
   magnitude below a nanosecond timestamp — so the loop recognizes it, reads the
@@ -41,10 +42,11 @@
   starts, `status` reports it as `"pending"` — even if it's mid-attempt (queued
   is the longer-lived of the two states it could be in) — and canceling it takes
   effect immediately but only clears its queue entry when that entry comes due.
-- This change is not backwards compatible. It requires `convex` 1.43 or later,
-  and downgrading a workpool that has run this version is not supported: an
-  older version would read a nanosecond timestamp as a 100ms bucket far in the
-  future and never start the work.
+- This change is not backwards compatible. It requires a `convex` release with
+  `ctx.meta.getSnapshotTs()` (TODO: pin the version once it ships), and
+  downgrading a workpool that has run this version is not supported: an older
+  version would read a nanosecond timestamp as a 100ms bucket far in the future
+  and never start the work.
 
 ## 0.4.10
 

--- a/example/BENCHMARKS.md
+++ b/example/BENCHMARKS.md
@@ -125,6 +125,16 @@ lateness is approximate: the harness starts its timer before calling the
 enqueuing mutation. Three recorded attempts do not independently prove the final
 retry's terminal result.
 
+If the long-delay CLI call errors or times out, check the existing run before
+retrying. The recorded 310-second run returned a generic CLI error even though
+the server action completed successfully; the cause was not established. Read
+persisted probes with `npx convex run test/scheduling:probes`, inspect the
+server action's completion/error logs, and check `testWorkpool` queue and
+running state using the drain checklist below. If work is still active, wait for
+it to settle. Archive that evidence before cleanup or another run: rerunning the
+command resets the probes and enqueues new delayed/retry work without canceling
+the previous work.
+
 ## Comparing a code change against itself
 
 Use the same component for both variants, with a build and successful deploy for
@@ -161,8 +171,8 @@ npx convex run test/cleanup:counts  # repeat until every count is zero
 Cleanup deletes **all** `tasks`, `latencyTasks`, `runs`, `schedulingProbes`, and
 `data`, including dashboard history. It does not clear `counters` or component
 tables, cancel tasks, or wait for workers. First verify each component has no
-`work`, `pendingStart`, `pendingCompletion`, `pendingCancelation`, or running
-entries. Then wait for all cleanup counts to reach zero; a missing/error
+`work`, `pendingStart`, `pendingCompletion`, `pendingCancelation`, `payload`, or
+running entries. Then wait for all cleanup counts to reach zero; a missing/error
 response is not zero. Concurrent runs and delayed leftovers can repopulate
 tables after cleanup.
 

--- a/example/BENCHMARKS.md
+++ b/example/BENCHMARKS.md
@@ -1,40 +1,66 @@
 # Benchmarking the workpool
 
+Recorded results: [2026-09-08, revision `8186121`](./benchmarks/2026-09-08.md).
+
 Harnesses in `example/convex/test/`, all driving a real deployment:
 
-| entry point                      | measures                                               |
-| -------------------------------- | ------------------------------------------------------ |
-| `test/scenarios/throughput`      | end-to-end throughput and completion latency           |
-| `test/latency:default`           | when tasks _start_, vs. when they were due             |
-| `test/latency:pairs`             | a scheduled task against a `commitTs` sibling          |
-| `test/latency:backlog`           | a late scheduled entry behind a bulk sharing one stamp |
-| `test/scheduling:default`        | delayed + retried work, end to end                     |
-| `test/cleanup:start` / `:counts` | empty the bookkeeping tables (see below)               |
+| entry point                            | measures                                        | pools     |
+| -------------------------------------- | ----------------------------------------------- | --------- |
+| `test/scenarios/throughput:default`    | end-to-end throughput and completion latency    | new / old |
+| `test/scenarios/burstyBatches:default` | concurrent enqueue waves, or a light trickle    | new / old |
+| `test/scenarios/sustained:default`     | paced arrivals with variable-duration actions   | new / old |
+| `test/scenarios/noisyNeighbor:run`     | slow/failing neighbors, per-class outcomes      | new / old |
+| `test/latency:default`                 | when tasks _start_, vs. when they were due      | new / old |
+| `test/latency:pairs`                   | scheduled tasks against an immediate sibling    | new / old |
+| `test/latency:backlog`                 | a late entry behind bulk scheduled work         | new / old |
+| `test/scheduling:default`              | delayed work and retry attempts                 | new only  |
+| `test/cleanup:start` / `:counts`       | clear app bookkeeping; does not drain workpools | shared    |
 
-Both can run against either component: `"pool": "new"` is this branch's
-`testWorkpool`, `"pool": "old"` is the published baseline mounted as
-`oldWorkpool`. Comparing the two in one run is the only way to attribute a
-change to the code rather than to the deployment.
+`"pool": "new"` is this checkout's `testWorkpool`; `"pool": "old"` is the
+published package mounted as `oldWorkpool`. Check the installed baseline rather
+than relying on dashboard labels or previous reports:
 
 ```sh
-npx convex dev --once   # push the component before measuring anything
+node -p 'require("./node_modules/@convex-dev/workpool-old/package.json").version'
+npm run build:codegen && npx convex dev --once
 ```
+
+Run commands from the repo root against a dedicated dev deployment. The example
+imports the component through its `dist` exports, so **build before deploying**.
+A failed deploy means the previous design is still running. In particular,
+pre-snapshot experimental deployments can retain the removed `lastCommitTs`
+field in `internalState`, causing schema validation to fail. Resolve that state
+compatibility issue before measuring; do not treat a failed push as a new build.
+
+Archive the commit, any source diff, dependency versions, deployment, exact
+arguments, raw outputs, and run order. Paired runs on one deployment help
+control time-varying noise, but different components still have different
+storage histories. They compare complete designs, not an isolated source change.
 
 ## Throughput
 
 ```sh
 npx convex run test/scenarios/throughput:default '{
   "taskCount": 5000, "batchSize": 100, "interBatchMs": 50,
-  "maxParallelism": 200, "taskDurationMs": 20,
-  "taskType": "mutation", "pool": "new"
+  "maxParallelism": 200, "taskType": "mutation", "pool": "new"
 }'
 ```
 
-Paired A/B against the baseline, alternating which arm leads each rep:
+Repeat with `"pool": "old"` for the baseline. For actions, use
+`"taskType": "action", "taskDurationMs": 20`. **`taskDurationMs` is ignored for
+mutations**, even though the current harness includes it in the returned
+parameters and log message. The mutation workload above performs no artificial
+delay or database workload beyond the completion recorder.
 
-```sh
-REPS=3 ./.context/bench-commitTs.sh
-```
+Discard warmups, then measure at least three pairs, alternating `old,new`,
+`new,old`, `old,new`. Clear bookkeeping and wait for both components to drain
+between arms. Save JSON before cleanup. Report individual runs, per-pair ratios,
+and the spread, not just the fastest run.
+
+`completedCount` currently counts terminal callbacks, including failures and
+cancelations: `markTaskCompleted` does not save `result.kind`. Check runtime
+errors as well as `timedOut`, `status`, and the exact expected count. A CLI exit
+code of zero alone does not establish that a benchmark finished successfully.
 
 ## Start latency and ordering
 
@@ -46,126 +72,140 @@ npx convex run test/latency:default '{
 }'
 ```
 
-Every task records its own start clock, so the returned rows support start
-lateness (`startedAt - runAt`), start ordering, and per-delay-class breakdowns.
-Options beyond the above: `holdOps` and `nestedCalls` stretch the enqueuing
-transaction, `interChunkMs` spreads enqueues out, `settleMs` bounds the wait.
+Every task records its own start clock, supporting start lateness
+(`startedAt - runAt`), start ordering, and per-delay-class breakdowns. `holdOps`
+and `nestedCalls` stretch the enqueuing transaction, `interChunkMs` spreads
+enqueues out, and `settleMs` bounds the additional wait.
 
-To ask whether the _ordering path_ costs anything, use `pairs` instead. It
-enqueues, in one transaction, a control task ordered by `db.vars.commitTs`
-alongside scheduled ones. The control shares the commit, so both become visible
-at the same instant, and when the transaction takes longer to commit than a
-delay that task is already overdue on landing — leaving any difference in start
-time attributable to the path rather than the wait.
+`pairs` enqueues an immediate control alongside scheduled tasks in one
+transaction. On the new pool the control is ordered by `db.vars.commitTs`; the
+old pool uses its own immediate ordering. Siblings become visible together. When
+a scheduled task is already overdue at commit, their start-time difference is
+useful for comparing scheduling paths, though execution noise and capacity still
+contribute.
 
 ```sh
 npx convex run test/latency:pairs '{
-  "cell": "demo", "pool": "new", "count": 40,
+  "cell": "pairs-demo", "pool": "new", "count": 40,
   "soonDelays": [200], "nestedCalls": 800, "maxParallelism": 200
 }'
 ```
 
-`backlog` puts a bulk of scheduled work sharing one commit stamp ahead of such a
-pair — the shape that once stalled the sweep:
+`backlog` puts bulk scheduled work sharing one commit stamp ahead of such a
+pair:
 
 ```sh
 npx convex run test/latency:backlog '{
-  "cell": "demo", "pool": "new", "bulkCount": 2000, "bulkDelayMs": 60000,
+  "cell": "backlog-demo", "pool": "new", "bulkCount": 2000, "bulkDelayMs": 60000,
   "soonDelayMs": 100, "nestedCalls": 800, "maxParallelism": 200
 }'
 ```
 
-Both need concurrent ready-now work to be meaningful — see the pool note below.
+For a behind-cursor experiment, both need light concurrent ready-now work — see
+the pool note below. The commands above do **not** generate that traffic. A
+completed pair without evidence that the incoming cursor passed the scheduled
+key is a latency sample, not proof the sweep ran. `committedAt` in the pair rows
+is the action's clock after the enqueue RPC returned, not the database commit
+timestamp; a worker can start before that observation.
+
+`backlog` returns when its two probes start, while the bulk may still be waiting
+for `bulkDelayMs`. Wait for that work to finish before cleaning up or running
+another cell. Use distinct `cell` names: `resetCell` deletes probe rows but does
+not cancel their queued tasks.
+
+The delayed/retry smoke check is separate and only supports the new pool:
+
+```sh
+npx convex run test/scheduling:default
+npx convex run test/scheduling:default '{"delayMs":310000}'
+```
+
+The second crosses the five-minute threshold where enqueues omit `scanTs`. Its
+lateness is approximate: the harness starts its timer before calling the
+enqueuing mutation. Three recorded attempts do not independently prove the final
+retry's terminal result.
 
 ## Comparing a code change against itself
 
-`.context/exp-consts.py` edits a constant in `loop.ts`, deploys, measures, and
-repeats — on the same component, in mirrored order, with cleanup between runs:
+Use the same component for both variants, with a build and successful deploy for
+each source change, discarded warmups, cleanup, and balanced run order. Keep
+edits in isolated checkouts so restoring a variant cannot overwrite other work.
+Do not change constants during a comparison of the current design against the
+published baseline.
 
-```sh
-python3 .context/exp-consts.py mainbatch    # MAIN_BATCH_SIZE 64/128/256
-```
-
-It refuses to run on a dirty `src/component` and restores via `git checkout`, so
-its own edits can't clobber work in flight. Findings from the runs already done
-are in `.context/README.md`.
+Historical `.context/bench-commitTs.sh`, `.context/exp-consts.py`, and
+experiment reports are workspace artifacts, not tracked tooling available in a
+fresh clone. They are not the authoritative procedure: their warmup counts/order
+differ from their comments, and restoring with `git checkout` can erase
+concurrent edits.
 
 ## Getting numbers you can trust
 
-Everything below was learned the hard way while producing
-`.context/scheduling-experiments.md` and `.context/commitTs-benchmark.md`.
+**Warm up, and discard it.** Earlier experiments showed substantial warmup
+drift. Start with three discarded runs per workload and pool, and check whether
+timings stabilize; three is a heuristic, not a guarantee. Balanced ordering does
+not automatically cancel nonlinear drift.
 
-**Warm up, and discard it.** The first runs against a deployment are reliably
-the slowest — one sequence went 20.9s → 19.1s → 17.0s → 16.1s before flattening,
-a ~20% drift that dwarfs most effects being measured. Three discarded runs is
-usually enough. A mirrored order (a,b,c,c,b,a) does _not_ rescue you here: the
-drift decays rather than being linear, so it doesn't cancel.
+**Prefer paired runs.** Report the within-pair throughput ratio as well as
+absolute measurements. Deployment-level variation can move both arms together. A
+ratio does not remove differences in component storage history.
 
-**Prefer paired runs.** Deployment-level noise moves both arms together; one rep
-of the throughput benchmark had both arms 15% slow while the ratio between them
-held to within a point. Trust the ratio over the absolute.
-
-**Clear the bookkeeping between runs.** This one matters more than everything
-else here:
+**Drain, archive, then clear bookkeeping between runs.** On this dedicated
+benchmark deployment:
 
 ```sh
-npx convex run test/cleanup:start     # then poll test/cleanup:counts
+npx convex run test/cleanup:start
+npx convex run test/cleanup:counts  # repeat until every count is zero
 ```
 
-`tasks` and `latencyTasks` gain a row per measured task, written from _inside_
-the measured path, and nothing reads them across runs. Left alone they reached
-659,075 and 87,680 rows in one session — so every run paid a different, growing
-index-maintenance cost on a table incidental to the thing being measured.
-Clearing between runs cut within-variant spread from 59% of the mean to 20%, and
-to 3–5% once warm. That is the difference between seeing a 6% effect and
-concluding there wasn't one.
+Cleanup deletes **all** `tasks`, `latencyTasks`, `runs`, `schedulingProbes`, and
+`data`, including dashboard history. It does not clear `counters` or component
+tables, cancel tasks, or wait for workers. First verify each component has no
+`work`, `pendingStart`, `pendingCompletion`, `pendingCancelation`, or running
+entries. Then wait for all cleanup counts to reach zero; a missing/error
+response is not zero. Concurrent runs and delayed leftovers can repopulate
+tables after cleanup.
 
-**Establish the noise floor before believing an effect.** Run the same
-configuration several times and look at the spread; that's the smallest
-difference the rig can see. A three-way comparison coming out non-monotonic (the
-middle variant fastest or slowest) is a reliable tell that you're reading noise,
-since no real effect can produce it.
+Bookkeeping writes are inside the measured path, so accumulated table state is a
+confound. Cleanup bounds live rows; it does not reset storage history or prove
+that the two components have identical costs.
 
-Resist "the infrastructure is flaky" as an explanation. It was reached once here
-and it was wrong — requests genuinely were being dropped, but the spread was
-accumulated state, and the conclusion was unfalsifiable as stated. Look for
-something growing between runs first.
+**Establish the noise floor before believing an effect.** Repeat identical
+configurations and inspect the spread before interpreting a small effect.
+Non-monotonic results are not proof of noise: batching, contention, and latency
+tradeoffs can produce a real optimum. Investigate accumulated state, offered
+load, failures, and resource limits before assigning a cause.
 
-**A transaction is one sample.** Every entry enqueued in a single transaction
-shares a commit stamp and a start time. Measuring 200 entries at once gives one
-Bernoulli trial, not 200 — the first pass at the out-of-order experiment
-produced all-or-nothing 200/0 results for exactly that reason. Use `chunkSize`.
+**A transaction is one sample for commit ordering.** Entries in one enqueue
+share a commit stamp and frozen enqueue clock. Their worker start times can
+differ because workers run in separate transactions. Treat a chunk as one
+correlated trial for out-of-order landing, and use `chunkSize` to obtain
+multiple transactions. Those transactions still share deployment-level noise.
 
-**Isolate a code change on one component.** Deploy variant A to `testWorkpool`
-and measure, then deploy variant B to the _same_ component and measure again.
-Running variant A on `testWorkpool` against variant B on `oldWorkpool` conflates
-the change with each component's accumulated table history; that confound once
-reversed a result entirely.
+**`Date.now()` is frozen inside a mutation.** A wall-clock spin loop cannot
+measure duration there. To stretch a transaction, count operations (`holdOps`)
+or call `nestedNoop` repeatedly (`nestedCalls`), and time it from an action,
+where the clock advances. These remain subject to function execution limits;
+nested calls that do database work consume budget.
 
-**A saturated pool hides scheduling effects.** With a backlog the loop's cursor
-lags wall-clock, so anything that depends on the cursor tracking the present
-(out-of-order landing, say) simply won't happen. Keep the pool drained — high
-`maxParallelism`, light load — when that's what you're measuring.
-
-**`Date.now()` is frozen inside a mutation.** A wall-clock spin loop never
-terminates; it burns the read limit and fails. To stretch a transaction, count
-operations instead (`holdOps`) or nest mutation calls (`nestedCalls`, which
-doesn't consume the read/write budget), and time it from an action, where the
-clock is real.
-
-**A saturated or idle pool hides anything cursor-related.** With a backlog the
-loop's cursor lags wall-clock; with an idle pool it doesn't move at all. Either
-way a scheduled entry is never behind it, so out-of-order landing simply cannot
-happen and the measurement comes back clean for the wrong reason. Those cells
-need light concurrent ready-now work at high `maxParallelism`.
+**Control pool load for cursor experiments.** A saturated pool's incoming cursor
+can lag, and an idle pool's cursor may not advance. Neither reliably produces
+the behind-cursor condition. Use light concurrent ready-now work at high
+`maxParallelism`, and verify cursor advancement and available capacity during
+the slow enqueue. High parallelism alone is insufficient.
 
 ## Reading a slow loop
 
-`npx convex logs --jsonl --success` is the fastest way to see where loop time
-goes; each entry carries execution time alongside documents read and written.
+```sh
+npx convex logs --jsonl --success
+```
 
-The signature worth recognising: **execution time up while read and write volume
-is down means round trips, not work.** That is how the packing regression was
-found — a sequential `await ctx.db.get()` inside a per-entry loop cost one round
-trip per entry, 64 per iteration, for a flat ~150ms. Batch point reads with
-`Promise.all`.
+Entries carry execution time and documents/bytes read and written. Execution
+time rising while read/write volume falls is a reason to inspect sequential
+round trips, not a diagnosis by itself. Check OCC and execution statistics too.
+A past packing regression came from sequential per-entry point reads;
+independent reads can be batched with `Promise.all`.
+
+Both current mounts use a nested `batchWorker`. Include
+`testWorkpool/batchWorker` and `oldWorkpool/batchWorker` when comparing loop
+executions; counting only the parent component misses loop scheduling.

--- a/example/README.md
+++ b/example/README.md
@@ -24,10 +24,10 @@ the vite config reads from the repo root (`envDir: "../"`).
 
 The dashboard is a single comparison workspace. Pick a preset (`burstyBatches`,
 `throughput`, `overhead`, `sustained`, `bigArgs`, `bigContext`, or
-`bigReturnTypes`) and it runs the published 0.4.7 baseline, then this branch,
-with identical parameters. The completed pair is selected automatically and
-rendered as outcome cards, throughput and latency charts, and recent-run history
-on the same page.
+`bigReturnTypes`) and it runs the published baseline pinned by
+`@convex-dev/workpool-old`, then this branch, with identical parameters. The
+completed pair is selected automatically and rendered as outcome cards,
+throughput and latency charts, and recent-run history on the same page.
 
 Scheduled-function instrumentation stays internal to the components. Backfill a
 checked run from its component system table with:

--- a/example/benchmarks/2026-09-08.json
+++ b/example/benchmarks/2026-09-08.json
@@ -1,0 +1,5865 @@
+{
+  "metadata": {
+    "commit": "8186121dd366db20b38536215d27496f5c553b4a",
+    "deployment": "precious-raven-853",
+    "started": "2026-09-09T01:40:27.924006+00:00",
+    "loopSha256": "675db597be3cf2d42b6147beff9e6e6866fff7bfd99a85254c3f22e626273513",
+    "baselineVersion": "0.4.9",
+    "laterCommentOnlyCommit": "0d80a6c7f4535594b1cb37e09e980d91bd0681c8",
+    "distLoopSha256": "c67b4679b49d20974c3ed59af0aaf1f269c8c2b9099d00a7126df7bd2b369de1",
+    "versions": {
+      "convex": "1.43.0",
+      "batchWorker": "0.2.1",
+      "baseline": "0.4.9",
+      "source": "0.4.10"
+    },
+    "timezone": "America/Los_Angeles",
+    "nodeVersion": "v22.22.2",
+    "preflight": {
+      "testsPassed": 148,
+      "testFilesPassed": 14,
+      "testRevision": "0d80a6c",
+      "builtAndDeployedRevision": "8186121"
+    },
+    "finished": "2026-09-09T02:18:30.704824+00:00",
+    "finalState": {
+      "testWorkpool": {
+        "counts": {
+          "payload": 0,
+          "pendingCancelation": 0,
+          "pendingCompletion": 0,
+          "pendingStart": 0,
+          "work": 0
+        },
+        "maxParallelism": 200,
+        "running": 0
+      },
+      "oldWorkpool": {
+        "counts": {
+          "payload": 0,
+          "pendingCancelation": 0,
+          "pendingCompletion": 0,
+          "pendingStart": 0,
+          "work": 0
+        },
+        "maxParallelism": 200,
+        "running": 0
+      },
+      "bookkeeping": {
+        "data": 0,
+        "latencyTasks": 0,
+        "runs": 0,
+        "schedulingProbes": 0,
+        "tasks": 0
+      }
+    },
+    "laterBehavioralCommit": "e94b0f3a0c4451e57902a99bc37bef3aafc4164b",
+    "laterLocalBuildDetectedAt": "2026-09-09T02:13:46Z",
+    "laterDeploymentVerified": false,
+    "finalDistLoopSha256": "b778b4862326f9bc75f96eed6535f7066c052d6dbd963e181a9c97342ba42af0",
+    "revisionScope": "Throughput and diagnostics before 02:13:46 UTC cover 8186121. Far-delay completion and trickle pairs 4\u20136 occurred after a concurrent e94b0f3 build; their deployment revision was not verified."
+  },
+  "runs": [
+    {
+      "label": "mutation-warmup-1-old",
+      "started": "2026-09-09T01:40:34.554691+00:00",
+      "phase": "warmup",
+      "rep": 1,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 15384,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 34630,
+            "p50": 15511,
+            "p95": 32794,
+            "p99": 34595
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 49963
+        },
+        "tasksPerSec": 100,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mutation-warmup-1-new",
+      "started": "2026-09-09T01:41:35.949496+00:00",
+      "phase": "warmup",
+      "rep": 1,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 12956,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 29953,
+            "p50": 15726,
+            "p95": 28606,
+            "p99": 29683
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 42812
+        },
+        "tasksPerSec": 117,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mutation-warmup-2-new",
+      "started": "2026-09-09T01:42:29.111590+00:00",
+      "phase": "warmup",
+      "rep": 2,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 10378,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 28627,
+            "p50": 14598,
+            "p95": 27348,
+            "p99": 28344
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 38873
+        },
+        "tasksPerSec": 129,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mutation-warmup-2-old",
+      "started": "2026-09-09T01:43:18.978031+00:00",
+      "phase": "warmup",
+      "rep": 2,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 10489,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 33490,
+            "p50": 15611,
+            "p95": 31903,
+            "p99": 33447
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 43884
+        },
+        "tasksPerSec": 114,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mutation-warmup-3-old",
+      "started": "2026-09-09T01:44:13.688900+00:00",
+      "phase": "warmup",
+      "rep": 3,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 9015,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 35420,
+            "p50": 15892,
+            "p95": 32873,
+            "p99": 35403
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 44344
+        },
+        "tasksPerSec": 113,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mutation-warmup-3-new",
+      "started": "2026-09-09T01:45:08.655404+00:00",
+      "phase": "warmup",
+      "rep": 3,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 9989,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 27568,
+            "p50": 14849,
+            "p95": 26159,
+            "p99": 27291
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 37445
+        },
+        "tasksPerSec": 134,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mutation-measured-1-old",
+      "started": "2026-09-09T01:45:56.592261+00:00",
+      "phase": "measured",
+      "rep": 1,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 9056,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 39439,
+            "p50": 16931,
+            "p95": 37140,
+            "p99": 38889
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 48417
+        },
+        "tasksPerSec": 103,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mutation-measured-1-new",
+      "started": "2026-09-09T01:46:55.814488+00:00",
+      "phase": "measured",
+      "rep": 1,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 8651,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 26853,
+            "p50": 12541,
+            "p95": 25441,
+            "p99": 26609
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 35491
+        },
+        "tasksPerSec": 141,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mutation-measured-2-new",
+      "started": "2026-09-09T01:47:43.965902+00:00",
+      "phase": "measured",
+      "rep": 2,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 9065,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 28248,
+            "p50": 12848,
+            "p95": 27162,
+            "p99": 27975
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 37250
+        },
+        "tasksPerSec": 134,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mutation-measured-2-old",
+      "started": "2026-09-09T01:48:31.878395+00:00",
+      "phase": "measured",
+      "rep": 2,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 8968,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 32239,
+            "p50": 14413,
+            "p95": 30669,
+            "p99": 32203
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 41108
+        },
+        "tasksPerSec": 122,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mutation-measured-3-old",
+      "started": "2026-09-09T01:49:23.896317+00:00",
+      "phase": "measured",
+      "rep": 3,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 9292,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 35240,
+            "p50": 16448,
+            "p95": 33480,
+            "p99": 35181
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 44325
+        },
+        "tasksPerSec": 113,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mutation-measured-3-new",
+      "started": "2026-09-09T01:50:18.922472+00:00",
+      "phase": "measured",
+      "rep": 3,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "mutation",
+        "pollTimeoutMs": 120000
+      },
+      "result": {
+        "enqueueTotal": 8167,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 25822,
+            "p50": 12935,
+            "p95": 24661,
+            "p99": 25543
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "mutation"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 33935
+        },
+        "tasksPerSec": 147,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-warmup-1-old",
+      "started": "2026-09-09T01:51:03.943269+00:00",
+      "phase": "warmup",
+      "rep": 1,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 9301,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 27573,
+            "p50": 12554,
+            "p95": 25946,
+            "p99": 27565
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 36785
+        },
+        "tasksPerSec": 136,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-warmup-1-new",
+      "started": "2026-09-09T01:51:51.200061+00:00",
+      "phase": "warmup",
+      "rep": 1,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 7769,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 19174,
+            "p50": 9329,
+            "p95": 18152,
+            "p99": 18872
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 26864
+        },
+        "tasksPerSec": 186,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-warmup-2-new",
+      "started": "2026-09-09T01:52:28.488326+00:00",
+      "phase": "warmup",
+      "rep": 2,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 7494,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 18085,
+            "p50": 9001,
+            "p95": 17015,
+            "p99": 17786
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 25511
+        },
+        "tasksPerSec": 196,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-warmup-2-old",
+      "started": "2026-09-09T01:53:04.072187+00:00",
+      "phase": "warmup",
+      "rep": 2,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 9425,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 29662,
+            "p50": 13487,
+            "p95": 28351,
+            "p99": 29651
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 38996
+        },
+        "tasksPerSec": 128,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-warmup-3-old",
+      "started": "2026-09-09T01:53:53.921210+00:00",
+      "phase": "warmup",
+      "rep": 3,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 9676,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 29676,
+            "p50": 13096,
+            "p95": 28055,
+            "p99": 29669
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 39249
+        },
+        "tasksPerSec": 127,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-warmup-3-new",
+      "started": "2026-09-09T01:54:44.357347+00:00",
+      "phase": "warmup",
+      "rep": 3,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 7357,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 19900,
+            "p50": 8956,
+            "p95": 18886,
+            "p99": 19585
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 27190
+        },
+        "tasksPerSec": 184,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-measured-1-old",
+      "started": "2026-09-09T01:55:22.052194+00:00",
+      "phase": "measured",
+      "rep": 1,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 9593,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 27906,
+            "p50": 12624,
+            "p95": 26525,
+            "p99": 27898
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 37408
+        },
+        "tasksPerSec": 134,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-measured-1-new",
+      "started": "2026-09-09T01:56:10.003042+00:00",
+      "phase": "measured",
+      "rep": 1,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 7942,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 18297,
+            "p50": 9250,
+            "p95": 17188,
+            "p99": 17970
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 26175
+        },
+        "tasksPerSec": 191,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-measured-2-new",
+      "started": "2026-09-09T01:56:46.440319+00:00",
+      "phase": "measured",
+      "rep": 2,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 7374,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 18192,
+            "p50": 9130,
+            "p95": 17160,
+            "p99": 17872
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 25483
+        },
+        "tasksPerSec": 196,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-measured-2-old",
+      "started": "2026-09-09T01:57:22.381364+00:00",
+      "phase": "measured",
+      "rep": 2,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 9080,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 27877,
+            "p50": 13228,
+            "p95": 25835,
+            "p99": 27869
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 36862
+        },
+        "tasksPerSec": 136,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-measured-3-old",
+      "started": "2026-09-09T01:58:09.506801+00:00",
+      "phase": "measured",
+      "rep": 3,
+      "pool": "old",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 8370,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 29481,
+            "p50": 13318,
+            "p95": 27858,
+            "p99": 28948
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 37767
+        },
+        "tasksPerSec": 132,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "action-measured-3-new",
+      "started": "2026-09-09T01:58:57.703056+00:00",
+      "phase": "measured",
+      "rep": 3,
+      "pool": "new",
+      "scenario": "throughput",
+      "args": {
+        "taskCount": 5000,
+        "batchSize": 100,
+        "interBatchMs": 50,
+        "maxParallelism": 200,
+        "taskType": "action",
+        "pollTimeoutMs": 120000,
+        "taskDurationMs": 20
+      },
+      "result": {
+        "enqueueTotal": 7751,
+        "metrics": {
+          "completedCount": 5000,
+          "latency": {
+            "max": 18307,
+            "p50": 8769,
+            "p95": 17485,
+            "p99": 18049
+          },
+          "parameters": {
+            "batchSize": 100,
+            "interBatchMs": 50,
+            "maxParallelism": 200,
+            "taskCount": 5000,
+            "taskDurationMs": 20,
+            "taskType": "action"
+          },
+          "scenario": "throughput",
+          "status": "completed",
+          "taskCount": 5000,
+          "totalDurationMs": 26064
+        },
+        "tasksPerSec": 192,
+        "timedOut": false
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "trickle-1-old",
+      "started": "2026-09-09T01:59:41.811445+00:00",
+      "phase": "measured",
+      "rep": 1,
+      "pool": "old",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 10980,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 1145,
+            "p50": 290,
+            "p95": 1132,
+            "p99": 1145
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 11238,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 296,
+              "p99": 296,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 195,
+              "p99": 195,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 170,
+              "p99": 170,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 354,
+              "p99": 354,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 366,
+              "p99": 366,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 1145,
+              "p99": 1145,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 1132,
+              "p99": 1132,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 695,
+              "p99": 695,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 251,
+              "p99": 251,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 259,
+              "p99": 259,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 808,
+              "p99": 808,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 661,
+              "p99": 661,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 274,
+              "p99": 274,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 338,
+              "p99": 338,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 313,
+              "p99": 313,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 287,
+              "p99": 287,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 290,
+              "p99": 290,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 254,
+              "p99": 254,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 237,
+              "p99": 237,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 271,
+              "p99": 271,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 152,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 40,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 297,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 23,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 330,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 45,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 213,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 23,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 39,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 21,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 37,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "trickle-1-new",
+      "started": "2026-09-09T02:00:01.725611+00:00",
+      "phase": "measured",
+      "rep": 1,
+      "pool": "new",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 11729,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 1923,
+            "p50": 446,
+            "p95": 1604,
+            "p99": 1923
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 12165,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 201,
+              "p99": 201,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 198,
+              "p99": 198,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 1604,
+              "p99": 1604,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 1305,
+              "p99": 1305,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 286,
+              "p99": 286,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 312,
+              "p99": 312,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 272,
+              "p99": 272,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 281,
+              "p99": 281,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 1923,
+              "p99": 1923,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 1381,
+              "p99": 1381,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 1144,
+              "p99": 1144,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 356,
+              "p99": 356,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 353,
+              "p99": 353,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 996,
+              "p99": 996,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 1294,
+              "p99": 1294,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 1109,
+              "p99": 1109,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 589,
+              "p99": 589,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 204,
+              "p99": 204,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 885,
+              "p99": 885,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 446,
+              "p99": 446,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 50,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 39,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 655,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 75,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 42,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 34,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 804,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 49,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 75,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 73,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 38,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 34,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "trickle-2-new",
+      "started": "2026-09-09T02:00:24.765916+00:00",
+      "phase": "measured",
+      "rep": 2,
+      "pool": "new",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 10337,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 488,
+            "p50": 244,
+            "p95": 443,
+            "p99": 488
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 10581,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 160,
+              "p99": 160,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 488,
+              "p99": 488,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 400,
+              "p99": 400,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 314,
+              "p99": 314,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 287,
+              "p99": 287,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 254,
+              "p99": 254,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 244,
+              "p99": 244,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 226,
+              "p99": 226,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 197,
+              "p99": 197,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 181,
+              "p99": 181,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 193,
+              "p99": 193,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 171,
+              "p99": 171,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 184,
+              "p99": 184,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 182,
+              "p99": 182,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 148,
+              "p99": 148,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 443,
+              "p99": 443,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 324,
+              "p99": 324,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 293,
+              "p99": 293,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 275,
+              "p99": 275,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 249,
+              "p99": 249,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 38,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 114,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 67,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 32,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 35,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 33,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 39,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 130,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "trickle-2-old",
+      "started": "2026-09-09T02:00:43.835416+00:00",
+      "phase": "measured",
+      "rep": 2,
+      "pool": "old",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 10935,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 928,
+            "p50": 247,
+            "p95": 604,
+            "p99": 928
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 11265,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 928,
+              "p99": 928,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 377,
+              "p99": 377,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 351,
+              "p99": 351,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 604,
+              "p99": 604,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 421,
+              "p99": 421,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 233,
+              "p99": 233,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 201,
+              "p99": 201,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 195,
+              "p99": 195,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 164,
+              "p99": 164,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 341,
+              "p99": 341,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 310,
+              "p99": 310,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 285,
+              "p99": 285,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 273,
+              "p99": 273,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 247,
+              "p99": 247,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 229,
+              "p99": 229,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 216,
+              "p99": 216,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 194,
+              "p99": 194,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 166,
+              "p99": 166,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 168,
+              "p99": 168,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 326,
+              "p99": 326,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 646,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 53,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 43,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 204,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 41,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 32,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "trickle-3-old",
+      "started": "2026-09-09T02:01:04.344878+00:00",
+      "phase": "measured",
+      "rep": 3,
+      "pool": "old",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 10182,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 393,
+            "p50": 208,
+            "p95": 350,
+            "p99": 393
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 10402,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 259,
+              "p99": 259,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 206,
+              "p99": 206,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 198,
+              "p99": 198,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 168,
+              "p99": 168,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 154,
+              "p99": 154,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 327,
+              "p99": 327,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 306,
+              "p99": 306,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 290,
+              "p99": 290,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 245,
+              "p99": 245,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 235,
+              "p99": 235,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 219,
+              "p99": 219,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 208,
+              "p99": 208,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 328,
+              "p99": 328,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 350,
+              "p99": 350,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 393,
+              "p99": 393,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 177,
+              "p99": 177,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 186,
+              "p99": 186,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 189,
+              "p99": 189,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 177,
+              "p99": 177,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 166,
+              "p99": 166,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 54,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 21,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 41,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 37,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 58,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 53,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 41,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "trickle-3-new",
+      "started": "2026-09-09T02:01:23.089990+00:00",
+      "phase": "measured",
+      "rep": 3,
+      "pool": "new",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 10625,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 1669,
+            "p50": 288,
+            "p95": 1430,
+            "p99": 1669
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 11168,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 1669,
+              "p99": 1669,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 1430,
+              "p99": 1430,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 802,
+              "p99": 802,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 400,
+              "p99": 400,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 193,
+              "p99": 193,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 164,
+              "p99": 164,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 1308,
+              "p99": 1308,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 1106,
+              "p99": 1106,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 851,
+              "p99": 851,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 352,
+              "p99": 352,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 288,
+              "p99": 288,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 269,
+              "p99": 269,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 265,
+              "p99": 265,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 270,
+              "p99": 270,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 228,
+              "p99": 228,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 214,
+              "p99": 214,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 196,
+              "p99": 196,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 180,
+              "p99": 180,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 372,
+              "p99": 372,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 347,
+              "p99": 347,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 38,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 32,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 410,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 38,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 44,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 90,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 32,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 45,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 40,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 38,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "trickle-4-new",
+      "started": "2026-09-09T02:15:46.953635+00:00",
+      "phase": "measured",
+      "rep": 4,
+      "pool": "new",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 10472,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 1496,
+            "p50": 261,
+            "p95": 1158,
+            "p99": 1496
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 10750,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 294,
+              "p99": 294,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 291,
+              "p99": 291,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 400,
+              "p99": 400,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 350,
+              "p99": 350,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 1496,
+              "p99": 1496,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 1158,
+              "p99": 1158,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 592,
+              "p99": 592,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 322,
+              "p99": 322,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 233,
+              "p99": 233,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 217,
+              "p99": 217,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 317,
+              "p99": 317,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 270,
+              "p99": 270,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 261,
+              "p99": 261,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 228,
+              "p99": 228,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 238,
+              "p99": 238,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 236,
+              "p99": 236,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 217,
+              "p99": 217,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 207,
+              "p99": 207,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 193,
+              "p99": 193,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 163,
+              "p99": 163,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 38,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 38,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 34,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 35,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 312,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 33,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 98,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 37,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": null,
+      "revisionVerifiedForComparison": false
+    },
+    {
+      "label": "trickle-4-old",
+      "started": "2026-09-09T02:16:06.095764+00:00",
+      "phase": "measured",
+      "rep": 4,
+      "pool": "old",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 10046,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 381,
+            "p50": 244,
+            "p95": 361,
+            "p99": 381
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 10492,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 278,
+              "p99": 278,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 244,
+              "p99": 244,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 215,
+              "p99": 215,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 194,
+              "p99": 194,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 176,
+              "p99": 176,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 361,
+              "p99": 361,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 328,
+              "p99": 328,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 315,
+              "p99": 315,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 290,
+              "p99": 290,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 301,
+              "p99": 301,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 276,
+              "p99": 276,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 252,
+              "p99": 252,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 234,
+              "p99": 234,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 216,
+              "p99": 216,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 223,
+              "p99": 223,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 182,
+              "p99": 182,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 168,
+              "p99": 168,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 161,
+              "p99": 161,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 337,
+              "p99": 337,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 381,
+              "p99": 381,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 28,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 35,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 34,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 34,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 23,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 22,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 20,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 23,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 21,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 22,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 22,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": null,
+      "revisionVerifiedForComparison": false
+    },
+    {
+      "label": "trickle-5-old",
+      "started": "2026-09-09T02:16:25.327142+00:00",
+      "phase": "measured",
+      "rep": 5,
+      "pool": "old",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 11069,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 1672,
+            "p50": 265,
+            "p95": 1160,
+            "p99": 1672
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 11661,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 180,
+              "p99": 180,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 205,
+              "p99": 205,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 191,
+              "p99": 191,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 349,
+              "p99": 349,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 381,
+              "p99": 381,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 359,
+              "p99": 359,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 250,
+              "p99": 250,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 265,
+              "p99": 265,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 262,
+              "p99": 262,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 205,
+              "p99": 205,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 179,
+              "p99": 179,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 196,
+              "p99": 196,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 299,
+              "p99": 299,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 1672,
+              "p99": 1672,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 1160,
+              "p99": 1160,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 738,
+              "p99": 738,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 620,
+              "p99": 620,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 729,
+              "p99": 729,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 194,
+              "p99": 194,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 593,
+              "p99": 593,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 35,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 119,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 71,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 660,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 55,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 23,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 246,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": null,
+      "revisionVerifiedForComparison": false
+    },
+    {
+      "label": "trickle-5-new",
+      "started": "2026-09-09T02:16:45.492342+00:00",
+      "phase": "measured",
+      "rep": 5,
+      "pool": "new",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 10180,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 697,
+            "p50": 221,
+            "p95": 440,
+            "p99": 697
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 10500,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 383,
+              "p99": 383,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 440,
+              "p99": 440,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 387,
+              "p99": 387,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 697,
+              "p99": 697,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 215,
+              "p99": 215,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 221,
+              "p99": 221,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 204,
+              "p99": 204,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 197,
+              "p99": 197,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 182,
+              "p99": 182,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 168,
+              "p99": 168,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 334,
+              "p99": 334,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 352,
+              "p99": 352,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 326,
+              "p99": 326,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 301,
+              "p99": 301,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 311,
+              "p99": 311,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 212,
+              "p99": 212,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 227,
+              "p99": 227,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 193,
+              "p99": 193,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 178,
+              "p99": 178,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 148,
+              "p99": 148,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 40,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 53,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 43,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 40,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 37,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 33,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 36,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 37,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": null,
+      "revisionVerifiedForComparison": false
+    },
+    {
+      "label": "trickle-6-new",
+      "started": "2026-09-09T02:17:04.184752+00:00",
+      "phase": "measured",
+      "rep": 6,
+      "pool": "new",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 10118,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 359,
+            "p50": 272,
+            "p95": 347,
+            "p99": 359
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 10360,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 165,
+              "p99": 165,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 335,
+              "p99": 335,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 308,
+              "p99": 308,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 279,
+              "p99": 279,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 275,
+              "p99": 275,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 249,
+              "p99": 249,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 225,
+              "p99": 225,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 199,
+              "p99": 199,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 169,
+              "p99": 169,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 359,
+              "p99": 359,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 347,
+              "p99": 347,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 339,
+              "p99": 339,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 311,
+              "p99": 311,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 300,
+              "p99": 300,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 272,
+              "p99": 272,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 264,
+              "p99": 264,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 242,
+              "p99": 242,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 280,
+              "p99": 280,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 260,
+              "p99": 260,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 248,
+              "p99": 248,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 36,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 34,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 35,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 33,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 31,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 27,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": null,
+      "revisionVerifiedForComparison": false
+    },
+    {
+      "label": "trickle-6-old",
+      "started": "2026-09-09T02:17:22.494517+00:00",
+      "phase": "measured",
+      "rep": 6,
+      "pool": "old",
+      "scenario": "burstyBatches",
+      "args": {
+        "waveCount": 20,
+        "tasksPerWave": 1,
+        "delayBetweenWavesMs": 500,
+        "taskType": "action",
+        "maxParallelism": 200,
+        "taskDurationMs": 50
+      },
+      "result": {
+        "enqueueTotal": 10066,
+        "metrics": {
+          "completedCount": 20,
+          "latency": {
+            "max": 348,
+            "p50": 253,
+            "p95": 346,
+            "p99": 348
+          },
+          "parameters": {
+            "delayBetweenWavesMs": 500,
+            "maxParallelism": 200,
+            "taskCount": 20,
+            "taskDurationMs": 50,
+            "taskType": "action",
+            "tasksPerWave": 1,
+            "waveCount": 20
+          },
+          "scenario": "burstyBatches",
+          "status": "completed",
+          "taskCount": 20,
+          "totalDurationMs": 10402,
+          "waves": [
+            {
+              "count": 1,
+              "p50": 174,
+              "p99": 174,
+              "wave": 0
+            },
+            {
+              "count": 1,
+              "p50": 346,
+              "p99": 346,
+              "wave": 1
+            },
+            {
+              "count": 1,
+              "p50": 305,
+              "p99": 305,
+              "wave": 2
+            },
+            {
+              "count": 1,
+              "p50": 285,
+              "p99": 285,
+              "wave": 3
+            },
+            {
+              "count": 1,
+              "p50": 273,
+              "p99": 273,
+              "wave": 4
+            },
+            {
+              "count": 1,
+              "p50": 252,
+              "p99": 252,
+              "wave": 5
+            },
+            {
+              "count": 1,
+              "p50": 227,
+              "p99": 227,
+              "wave": 6
+            },
+            {
+              "count": 1,
+              "p50": 211,
+              "p99": 211,
+              "wave": 7
+            },
+            {
+              "count": 1,
+              "p50": 187,
+              "p99": 187,
+              "wave": 8
+            },
+            {
+              "count": 1,
+              "p50": 164,
+              "p99": 164,
+              "wave": 9
+            },
+            {
+              "count": 1,
+              "p50": 348,
+              "p99": 348,
+              "wave": 10
+            },
+            {
+              "count": 1,
+              "p50": 326,
+              "p99": 326,
+              "wave": 11
+            },
+            {
+              "count": 1,
+              "p50": 317,
+              "p99": 317,
+              "wave": 12
+            },
+            {
+              "count": 1,
+              "p50": 301,
+              "p99": 301,
+              "wave": 13
+            },
+            {
+              "count": 1,
+              "p50": 278,
+              "p99": 278,
+              "wave": 14
+            },
+            {
+              "count": 1,
+              "p50": 253,
+              "p99": 253,
+              "wave": 15
+            },
+            {
+              "count": 1,
+              "p50": 227,
+              "p99": 227,
+              "wave": 16
+            },
+            {
+              "count": 1,
+              "p50": 198,
+              "p99": 198,
+              "wave": 17
+            },
+            {
+              "count": 1,
+              "p50": 178,
+              "p99": 178,
+              "wave": 18
+            },
+            {
+              "count": 1,
+              "p50": 346,
+              "p99": 346,
+              "wave": 19
+            }
+          ]
+        },
+        "timedOut": false,
+        "waveTimings": [
+          {
+            "enqueueMs": 37,
+            "wave": 0
+          },
+          {
+            "enqueueMs": 34,
+            "wave": 1
+          },
+          {
+            "enqueueMs": 22,
+            "wave": 2
+          },
+          {
+            "enqueueMs": 30,
+            "wave": 3
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 4
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 5
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 6
+          },
+          {
+            "enqueueMs": 23,
+            "wave": 7
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 8
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 9
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 10
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 11
+          },
+          {
+            "enqueueMs": 28,
+            "wave": 12
+          },
+          {
+            "enqueueMs": 26,
+            "wave": 13
+          },
+          {
+            "enqueueMs": 23,
+            "wave": 14
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 15
+          },
+          {
+            "enqueueMs": 24,
+            "wave": 16
+          },
+          {
+            "enqueueMs": 25,
+            "wave": 17
+          },
+          {
+            "enqueueMs": 35,
+            "wave": 18
+          },
+          {
+            "enqueueMs": 29,
+            "wave": 19
+          }
+        ]
+      },
+      "runtimeRevision": null,
+      "revisionVerifiedForComparison": false
+    }
+  ],
+  "checks": [
+    {
+      "label": "mixed-old",
+      "args": {
+        "cell": "mixed-old",
+        "pool": "old",
+        "groups": [
+          {
+            "delayMs": 3000,
+            "count": 600
+          },
+          {
+            "delayMs": 0,
+            "count": 2000
+          }
+        ],
+        "chunkSize": 25,
+        "maxParallelism": 200,
+        "settleMs": 120000
+      },
+      "result": {
+        "cell": "mixed-old",
+        "chunkMs": {
+          "max": 1621,
+          "median": 224,
+          "min": 185,
+          "n": 104
+        },
+        "enqueueMs": 27221,
+        "missing": 0,
+        "pool": "old",
+        "total": 2600,
+        "startLatenessByDelayMs": {
+          "0": {
+            "total": 2000,
+            "started": 2000,
+            "missing": 0,
+            "early": 0,
+            "min": 502,
+            "p50": 909,
+            "p95": 2144,
+            "max": 2558
+          },
+          "3000": {
+            "total": 600,
+            "started": 600,
+            "missing": 0,
+            "early": 0,
+            "min": 68,
+            "p50": 263,
+            "p95": 2192,
+            "max": 2415
+          }
+        }
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "mixed-new",
+      "args": {
+        "cell": "mixed-new",
+        "pool": "new",
+        "groups": [
+          {
+            "delayMs": 3000,
+            "count": 600
+          },
+          {
+            "delayMs": 0,
+            "count": 2000
+          }
+        ],
+        "chunkSize": 25,
+        "maxParallelism": 200,
+        "settleMs": 120000
+      },
+      "result": {
+        "cell": "mixed-new",
+        "chunkMs": {
+          "max": 1176,
+          "median": 226,
+          "min": 188,
+          "n": 104
+        },
+        "enqueueMs": 25405,
+        "missing": 0,
+        "pool": "new",
+        "total": 2600,
+        "startLatenessByDelayMs": {
+          "0": {
+            "total": 2000,
+            "started": 2000,
+            "missing": 0,
+            "early": 0,
+            "min": 346,
+            "p50": 618,
+            "p95": 1077,
+            "max": 2624
+          },
+          "3000": {
+            "total": 600,
+            "started": 600,
+            "missing": 0,
+            "early": 0,
+            "min": 126,
+            "p50": 317,
+            "p95": 1901,
+            "max": 2079
+          }
+        }
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "pairs-old",
+      "args": {
+        "cell": "pairs-old",
+        "pool": "old",
+        "count": 12,
+        "soonDelays": [200],
+        "nestedCalls": 800,
+        "maxParallelism": 200,
+        "settleMs": 60000
+      },
+      "result": {
+        "cell": "pairs-old",
+        "expected": 24,
+        "missing": 0,
+        "pool": "old",
+        "rows": [
+          {
+            "committedAt": 1788919388906,
+            "delayMs": 0,
+            "enqueuedAt": 1788919386815,
+            "pairId": 0,
+            "runAt": 1788919386815,
+            "startedAt": 1788919388979
+          },
+          {
+            "committedAt": 1788919388906,
+            "delayMs": 200,
+            "enqueuedAt": 1788919386815,
+            "pairId": 0,
+            "runAt": 1788919387015,
+            "startedAt": 1788919388980
+          },
+          {
+            "committedAt": 1788919390864,
+            "delayMs": 0,
+            "enqueuedAt": 1788919388931,
+            "pairId": 1,
+            "runAt": 1788919388931,
+            "startedAt": 1788919390919
+          },
+          {
+            "committedAt": 1788919390864,
+            "delayMs": 200,
+            "enqueuedAt": 1788919388931,
+            "pairId": 1,
+            "runAt": 1788919389131,
+            "startedAt": 1788919390919
+          },
+          {
+            "committedAt": 1788919392664,
+            "delayMs": 0,
+            "enqueuedAt": 1788919390888,
+            "pairId": 2,
+            "runAt": 1788919390888,
+            "startedAt": 1788919392739
+          },
+          {
+            "committedAt": 1788919392664,
+            "delayMs": 200,
+            "enqueuedAt": 1788919390888,
+            "pairId": 2,
+            "runAt": 1788919391088,
+            "startedAt": 1788919392739
+          },
+          {
+            "committedAt": 1788919394462,
+            "delayMs": 0,
+            "enqueuedAt": 1788919392684,
+            "pairId": 3,
+            "runAt": 1788919392684,
+            "startedAt": 1788919394531
+          },
+          {
+            "committedAt": 1788919394462,
+            "delayMs": 200,
+            "enqueuedAt": 1788919392684,
+            "pairId": 3,
+            "runAt": 1788919392884,
+            "startedAt": 1788919394531
+          },
+          {
+            "committedAt": 1788919396365,
+            "delayMs": 0,
+            "enqueuedAt": 1788919394678,
+            "pairId": 4,
+            "runAt": 1788919394678,
+            "startedAt": 1788919396422
+          },
+          {
+            "committedAt": 1788919396365,
+            "delayMs": 200,
+            "enqueuedAt": 1788919394678,
+            "pairId": 4,
+            "runAt": 1788919394878,
+            "startedAt": 1788919396422
+          },
+          {
+            "committedAt": 1788919397916,
+            "delayMs": 0,
+            "enqueuedAt": 1788919396384,
+            "pairId": 5,
+            "runAt": 1788919396384,
+            "startedAt": 1788919398179
+          },
+          {
+            "committedAt": 1788919397916,
+            "delayMs": 200,
+            "enqueuedAt": 1788919396384,
+            "pairId": 5,
+            "runAt": 1788919396584,
+            "startedAt": 1788919398179
+          },
+          {
+            "committedAt": 1788919399467,
+            "delayMs": 0,
+            "enqueuedAt": 1788919397936,
+            "pairId": 6,
+            "runAt": 1788919397936,
+            "startedAt": 1788919399626
+          },
+          {
+            "committedAt": 1788919399467,
+            "delayMs": 200,
+            "enqueuedAt": 1788919397936,
+            "pairId": 6,
+            "runAt": 1788919398136,
+            "startedAt": 1788919399629
+          },
+          {
+            "committedAt": 1788919401085,
+            "delayMs": 0,
+            "enqueuedAt": 1788919399488,
+            "pairId": 7,
+            "runAt": 1788919399488,
+            "startedAt": 1788919401182
+          },
+          {
+            "committedAt": 1788919401085,
+            "delayMs": 200,
+            "enqueuedAt": 1788919399488,
+            "pairId": 7,
+            "runAt": 1788919399688,
+            "startedAt": 1788919401181
+          },
+          {
+            "committedAt": 1788919402702,
+            "delayMs": 0,
+            "enqueuedAt": 1788919401103,
+            "pairId": 8,
+            "runAt": 1788919401103,
+            "startedAt": 1788919402868
+          },
+          {
+            "committedAt": 1788919402702,
+            "delayMs": 200,
+            "enqueuedAt": 1788919401103,
+            "pairId": 8,
+            "runAt": 1788919401303,
+            "startedAt": 1788919402868
+          },
+          {
+            "committedAt": 1788919404192,
+            "delayMs": 0,
+            "enqueuedAt": 1788919402725,
+            "pairId": 9,
+            "runAt": 1788919402725,
+            "startedAt": 1788919404431
+          },
+          {
+            "committedAt": 1788919404192,
+            "delayMs": 200,
+            "enqueuedAt": 1788919402725,
+            "pairId": 9,
+            "runAt": 1788919402925,
+            "startedAt": 1788919404431
+          },
+          {
+            "committedAt": 1788919405891,
+            "delayMs": 0,
+            "enqueuedAt": 1788919404212,
+            "pairId": 10,
+            "runAt": 1788919404212,
+            "startedAt": 1788919405991
+          },
+          {
+            "committedAt": 1788919405891,
+            "delayMs": 200,
+            "enqueuedAt": 1788919404212,
+            "pairId": 10,
+            "runAt": 1788919404412,
+            "startedAt": 1788919405990
+          },
+          {
+            "committedAt": 1788919407491,
+            "delayMs": 0,
+            "enqueuedAt": 1788919405914,
+            "pairId": 11,
+            "runAt": 1788919405914,
+            "startedAt": 1788919407703
+          },
+          {
+            "committedAt": 1788919407491,
+            "delayMs": 200,
+            "enqueuedAt": 1788919405914,
+            "pairId": 11,
+            "runAt": 1788919406114,
+            "startedAt": 1788919407703
+          }
+        ]
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "backlog-old",
+      "args": {
+        "cell": "backlog-old",
+        "pool": "old",
+        "bulkCount": 2000,
+        "bulkDelayMs": 60000,
+        "soonDelayMs": 100,
+        "nestedCalls": 800,
+        "maxParallelism": 200,
+        "settleMs": 90000
+      },
+      "result": {
+        "commitMs": 1622,
+        "immLatenessMs": 2963,
+        "soonLatenessMs": 2661,
+        "soonMinusImmMs": -202,
+        "soonStarted": true
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "cursor-bg-old",
+      "args": {
+        "cell": "cursor-bg-old",
+        "pool": "old",
+        "groups": [
+          {
+            "delayMs": 0,
+            "count": 1000
+          }
+        ],
+        "chunkSize": 1,
+        "interChunkMs": 100,
+        "maxParallelism": 200,
+        "settleMs": 60000
+      },
+      "result": {
+        "cell": "cursor-bg-old",
+        "chunkMs": {
+          "max": 1167,
+          "median": 29,
+          "min": 21,
+          "n": 1000
+        },
+        "enqueueMs": 142888,
+        "missing": 0,
+        "pool": "old",
+        "total": 1000,
+        "startLatenessByDelayMs": {
+          "0": {
+            "total": 1000,
+            "started": 1000,
+            "missing": 0,
+            "early": 0,
+            "min": 71,
+            "p50": 177,
+            "p95": 10112,
+            "max": 16882
+          }
+        }
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "backlog-drained-old",
+      "args": {
+        "cell": "backlog-old",
+        "pool": "old",
+        "bulkCount": 2000,
+        "bulkDelayMs": 60000,
+        "soonDelayMs": 100,
+        "nestedCalls": 800,
+        "maxParallelism": 200,
+        "settleMs": 90000
+      },
+      "result": {
+        "total": 2002,
+        "startLatenessByDelayMs": {
+          "0": {
+            "total": 1,
+            "started": 1,
+            "missing": 0,
+            "early": 0,
+            "min": 2963,
+            "p50": 2963,
+            "p95": 2963,
+            "max": 2963
+          },
+          "100": {
+            "total": 1,
+            "started": 1,
+            "missing": 0,
+            "early": 0,
+            "min": 2661,
+            "p50": 2661,
+            "p95": 2661,
+            "max": 2661
+          },
+          "60000": {
+            "total": 2000,
+            "started": 2000,
+            "missing": 0,
+            "early": 0,
+            "min": 258,
+            "p50": 6809,
+            "p95": 16379,
+            "max": 16859
+          }
+        }
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "pairs-new",
+      "args": {
+        "cell": "pairs-new",
+        "pool": "new",
+        "count": 12,
+        "soonDelays": [200],
+        "nestedCalls": 800,
+        "maxParallelism": 200,
+        "settleMs": 60000
+      },
+      "result": {
+        "cell": "pairs-new",
+        "expected": 24,
+        "missing": 0,
+        "pool": "new",
+        "rows": [
+          {
+            "committedAt": 1788919542862,
+            "delayMs": 0,
+            "enqueuedAt": 1788919541122,
+            "pairId": 0,
+            "runAt": 1788919541122,
+            "startedAt": 1788919542949
+          },
+          {
+            "committedAt": 1788919542862,
+            "delayMs": 200,
+            "enqueuedAt": 1788919541122,
+            "pairId": 0,
+            "runAt": 1788919541322,
+            "startedAt": 1788919542950
+          },
+          {
+            "committedAt": 1788919544898,
+            "delayMs": 0,
+            "enqueuedAt": 1788919542880,
+            "pairId": 1,
+            "runAt": 1788919542880,
+            "startedAt": 1788919545003
+          },
+          {
+            "committedAt": 1788919544898,
+            "delayMs": 200,
+            "enqueuedAt": 1788919542880,
+            "pairId": 1,
+            "runAt": 1788919543080,
+            "startedAt": 1788919545004
+          },
+          {
+            "committedAt": 1788919546465,
+            "delayMs": 0,
+            "enqueuedAt": 1788919544918,
+            "pairId": 2,
+            "runAt": 1788919544918,
+            "startedAt": 1788919546589
+          },
+          {
+            "committedAt": 1788919546465,
+            "delayMs": 200,
+            "enqueuedAt": 1788919544918,
+            "pairId": 2,
+            "runAt": 1788919545118,
+            "startedAt": 1788919546589
+          },
+          {
+            "committedAt": 1788919548079,
+            "delayMs": 0,
+            "enqueuedAt": 1788919546482,
+            "pairId": 3,
+            "runAt": 1788919546482,
+            "startedAt": 1788919548313
+          },
+          {
+            "committedAt": 1788919548079,
+            "delayMs": 200,
+            "enqueuedAt": 1788919546482,
+            "pairId": 3,
+            "runAt": 1788919546682,
+            "startedAt": 1788919548314
+          },
+          {
+            "committedAt": 1788919549746,
+            "delayMs": 0,
+            "enqueuedAt": 1788919548095,
+            "pairId": 4,
+            "runAt": 1788919548095,
+            "startedAt": 1788919549866
+          },
+          {
+            "committedAt": 1788919549746,
+            "delayMs": 200,
+            "enqueuedAt": 1788919548095,
+            "pairId": 4,
+            "runAt": 1788919548295,
+            "startedAt": 1788919549866
+          },
+          {
+            "committedAt": 1788919551274,
+            "delayMs": 0,
+            "enqueuedAt": 1788919549761,
+            "pairId": 5,
+            "runAt": 1788919549761,
+            "startedAt": 1788919551472
+          },
+          {
+            "committedAt": 1788919551274,
+            "delayMs": 200,
+            "enqueuedAt": 1788919549761,
+            "pairId": 5,
+            "runAt": 1788919549961,
+            "startedAt": 1788919551472
+          },
+          {
+            "committedAt": 1788919552869,
+            "delayMs": 0,
+            "enqueuedAt": 1788919551294,
+            "pairId": 6,
+            "runAt": 1788919551294,
+            "startedAt": 1788919553028
+          },
+          {
+            "committedAt": 1788919552869,
+            "delayMs": 200,
+            "enqueuedAt": 1788919551294,
+            "pairId": 6,
+            "runAt": 1788919551494,
+            "startedAt": 1788919553027
+          },
+          {
+            "committedAt": 1788919554466,
+            "delayMs": 0,
+            "enqueuedAt": 1788919552885,
+            "pairId": 7,
+            "runAt": 1788919552885,
+            "startedAt": 1788919554597
+          },
+          {
+            "committedAt": 1788919554466,
+            "delayMs": 200,
+            "enqueuedAt": 1788919552885,
+            "pairId": 7,
+            "runAt": 1788919553085,
+            "startedAt": 1788919554598
+          },
+          {
+            "committedAt": 1788919555992,
+            "delayMs": 0,
+            "enqueuedAt": 1788919554483,
+            "pairId": 8,
+            "runAt": 1788919554483,
+            "startedAt": 1788919556128
+          },
+          {
+            "committedAt": 1788919555992,
+            "delayMs": 200,
+            "enqueuedAt": 1788919554483,
+            "pairId": 8,
+            "runAt": 1788919554683,
+            "startedAt": 1788919556126
+          },
+          {
+            "committedAt": 1788919557549,
+            "delayMs": 0,
+            "enqueuedAt": 1788919556031,
+            "pairId": 9,
+            "runAt": 1788919556031,
+            "startedAt": 1788919557667
+          },
+          {
+            "committedAt": 1788919557549,
+            "delayMs": 200,
+            "enqueuedAt": 1788919556031,
+            "pairId": 9,
+            "runAt": 1788919556231,
+            "startedAt": 1788919557669
+          },
+          {
+            "committedAt": 1788919559445,
+            "delayMs": 0,
+            "enqueuedAt": 1788919557577,
+            "pairId": 10,
+            "runAt": 1788919557577,
+            "startedAt": 1788919559644
+          },
+          {
+            "committedAt": 1788919559445,
+            "delayMs": 200,
+            "enqueuedAt": 1788919557577,
+            "pairId": 10,
+            "runAt": 1788919557777,
+            "startedAt": 1788919559649
+          },
+          {
+            "committedAt": 1788919561108,
+            "delayMs": 0,
+            "enqueuedAt": 1788919559468,
+            "pairId": 11,
+            "runAt": 1788919559468,
+            "startedAt": 1788919561171
+          },
+          {
+            "committedAt": 1788919561108,
+            "delayMs": 200,
+            "enqueuedAt": 1788919559468,
+            "pairId": 11,
+            "runAt": 1788919559668,
+            "startedAt": 1788919561171
+          }
+        ]
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "backlog-new",
+      "args": {
+        "cell": "backlog-new",
+        "pool": "new",
+        "bulkCount": 2000,
+        "bulkDelayMs": 60000,
+        "soonDelayMs": 100,
+        "nestedCalls": 800,
+        "maxParallelism": 200,
+        "settleMs": 90000
+      },
+      "result": {
+        "commitMs": 1577,
+        "immLatenessMs": 1722,
+        "soonLatenessMs": 1622,
+        "soonMinusImmMs": 0,
+        "soonStarted": true
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "cursor-bg-new",
+      "args": {
+        "cell": "cursor-bg-new",
+        "pool": "new",
+        "groups": [
+          {
+            "delayMs": 0,
+            "count": 1000
+          }
+        ],
+        "chunkSize": 1,
+        "interChunkMs": 100,
+        "maxParallelism": 200,
+        "settleMs": 60000
+      },
+      "result": {
+        "cell": "cursor-bg-new",
+        "chunkMs": {
+          "max": 1128,
+          "median": 31,
+          "min": 22,
+          "n": 1000
+        },
+        "enqueueMs": 136982,
+        "missing": 0,
+        "pool": "new",
+        "total": 1000,
+        "startLatenessByDelayMs": {
+          "0": {
+            "total": 1000,
+            "started": 1000,
+            "missing": 0,
+            "early": 0,
+            "min": 78,
+            "p50": 217,
+            "p95": 4344,
+            "max": 13644
+          }
+        }
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "backlog-drained-new",
+      "args": {
+        "cell": "backlog-new",
+        "pool": "new",
+        "bulkCount": 2000,
+        "bulkDelayMs": 60000,
+        "soonDelayMs": 100,
+        "nestedCalls": 800,
+        "maxParallelism": 200,
+        "settleMs": 90000
+      },
+      "result": {
+        "total": 2002,
+        "startLatenessByDelayMs": {
+          "0": {
+            "total": 1,
+            "started": 1,
+            "missing": 0,
+            "early": 0,
+            "min": 1722,
+            "p50": 1722,
+            "p95": 1722,
+            "max": 1722
+          },
+          "100": {
+            "total": 1,
+            "started": 1,
+            "missing": 0,
+            "early": 0,
+            "min": 1622,
+            "p50": 1622,
+            "p95": 1622,
+            "max": 1622
+          },
+          "60000": {
+            "total": 2000,
+            "started": 2000,
+            "missing": 0,
+            "early": 0,
+            "min": 266,
+            "p50": 6574,
+            "p95": 12904,
+            "max": 13685
+          }
+        }
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "slowNeighbor-old",
+      "args": {
+        "preset": "slowNeighbor",
+        "pool": "old"
+      },
+      "result": {
+        "completedCount": 32,
+        "labels": [
+          {
+            "count": 28,
+            "label": "fast",
+            "latencyMs": {
+              "max": 132,
+              "min": 108,
+              "p50": 122,
+              "p95": 131
+            },
+            "results": {
+              "success": 28
+            }
+          },
+          {
+            "count": 4,
+            "label": "slow",
+            "latencyMs": {
+              "max": 20171,
+              "min": 20058,
+              "p50": 20107,
+              "p95": 20171
+            },
+            "results": {
+              "success": 4
+            }
+          }
+        ],
+        "pool": "old",
+        "scenario": "noisyNeighbor:slowNeighbor",
+        "status": "completed",
+        "taskCount": 32
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "slowNeighbor-new",
+      "args": {
+        "preset": "slowNeighbor",
+        "pool": "new"
+      },
+      "result": {
+        "completedCount": 32,
+        "labels": [
+          {
+            "count": 28,
+            "label": "fast",
+            "latencyMs": {
+              "max": 215,
+              "min": 203,
+              "p50": 214,
+              "p95": 215
+            },
+            "results": {
+              "success": 28
+            }
+          },
+          {
+            "count": 4,
+            "label": "slow",
+            "latencyMs": {
+              "max": 20247,
+              "min": 20158,
+              "p50": 20213,
+              "p95": 20247
+            },
+            "results": {
+              "success": 4
+            }
+          }
+        ],
+        "pool": "new",
+        "scenario": "noisyNeighbor:slowNeighbor",
+        "status": "completed",
+        "taskCount": 32
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "failRetry-old",
+      "args": {
+        "preset": "failRetry",
+        "pool": "old"
+      },
+      "result": {
+        "completedCount": 32,
+        "labels": [
+          {
+            "count": 8,
+            "label": "fail",
+            "latencyMs": {
+              "max": 1894,
+              "min": 1103,
+              "p50": 1365,
+              "p95": 1894
+            },
+            "results": {
+              "failed": 8
+            }
+          },
+          {
+            "count": 24,
+            "label": "fast",
+            "latencyMs": {
+              "max": 118,
+              "min": 100,
+              "p50": 110,
+              "p95": 118
+            },
+            "results": {
+              "success": 24
+            }
+          }
+        ],
+        "pool": "old",
+        "scenario": "noisyNeighbor:failRetry",
+        "status": "completed",
+        "taskCount": 32
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "failRetry-new",
+      "args": {
+        "preset": "failRetry",
+        "pool": "new"
+      },
+      "result": {
+        "completedCount": 32,
+        "labels": [
+          {
+            "count": 8,
+            "label": "fail",
+            "latencyMs": {
+              "max": 1990,
+              "min": 1928,
+              "p50": 1989,
+              "p95": 1990
+            },
+            "results": {
+              "failed": 8
+            }
+          },
+          {
+            "count": 24,
+            "label": "fast",
+            "latencyMs": {
+              "max": 266,
+              "min": 259,
+              "p50": 265,
+              "p95": 266
+            },
+            "results": {
+              "success": 24
+            }
+          }
+        ],
+        "pool": "new",
+        "scenario": "noisyNeighbor:failRetry",
+        "status": "completed",
+        "taskCount": 32
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "scheduling-8000",
+      "args": {
+        "delayMs": 8000
+      },
+      "result": {
+        "delayedLateByMs": 120,
+        "delayedRan": true,
+        "delayedRanEarly": false,
+        "retryAttempts": 3,
+        "actualStoredDueMs": 1788919785042,
+        "actualStartLatenessMs": 118,
+        "hasScanTs": true,
+        "retryGapsMs": [928, 1768]
+      },
+      "runtimeRevision": "8186121",
+      "revisionVerifiedForComparison": true
+    },
+    {
+      "label": "scheduling-310000",
+      "args": {
+        "delayMs": 310000
+      },
+      "result": {
+        "delayedRan": true,
+        "delayedRanEarly": false,
+        "delayedLateByMs": null,
+        "retryAttempts": 3,
+        "actualStoredDueMs": 1788920103659,
+        "actualStartLatenessMs": 365,
+        "hasScanTs": false,
+        "retryGapsMs": [953, 1985],
+        "cliResultUnavailable": true,
+        "recoveredFromPersistedProbes": true,
+        "serverActionCompletedWithoutError": true
+      },
+      "runtimeRevision": null,
+      "revisionVerifiedForComparison": false
+    }
+  ],
+  "validation": {
+    "expectedRuntimeErrors": {
+      "test/noisy:noisyAction": 48,
+      "test/scheduling:failTwice": 4
+    },
+    "unexpectedRuntimeErrors": 0,
+    "consoleErrorEntries": 52
+  },
+  "executionSummary": [
+    {
+      "label": "mutation-measured-1-old",
+      "component": "oldWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 84,
+      "readDocs": 30917,
+      "readBytes": 11317898,
+      "ioReadBytes": 11317898,
+      "writeDocs": 10167,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 492.5805772142857,
+      "p95Ms": 785.7500990000001
+    },
+    {
+      "label": "mutation-measured-1-old",
+      "component": "oldWorkpool",
+      "function": "worker:runMutationWrapper",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 52.0949992662,
+      "p95Ms": 128.18899
+    },
+    {
+      "label": "mutation-measured-1-old",
+      "component": "oldWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 10030000,
+      "ioReadBytes": 10030000,
+      "writeDocs": 10000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 63.312241217,
+      "p95Ms": 87.446283
+    },
+    {
+      "label": "mutation-measured-1-old",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 66,
+      "readDocs": 186503,
+      "readBytes": 50915257,
+      "ioReadBytes": 50915257,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 361.46932016666665,
+      "p95Ms": 1030.6275309999999
+    },
+    {
+      "label": "mutation-measured-1-new",
+      "component": "testWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 86,
+      "readDocs": 16224,
+      "readBytes": 9068848,
+      "ioReadBytes": 9068848,
+      "writeDocs": 5292,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 311.3259808255814,
+      "p95Ms": 460.184284
+    },
+    {
+      "label": "mutation-measured-1-new",
+      "component": "testWorkpool",
+      "function": "worker:runMutationWrapper",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 13.5240312794,
+      "p95Ms": 19.687984
+    },
+    {
+      "label": "mutation-measured-1-new",
+      "component": "testWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 10765000,
+      "ioReadBytes": 10765000,
+      "writeDocs": 10000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 38.6628605854,
+      "p95Ms": 52.706527
+    },
+    {
+      "label": "mutation-measured-1-new",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 51,
+      "readDocs": 151432,
+      "readBytes": 41340885,
+      "ioReadBytes": 41340885,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 299.81155007843137,
+      "p95Ms": 496.513541
+    },
+    {
+      "label": "mutation-measured-2-new",
+      "component": "testWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 84,
+      "readDocs": 16251,
+      "readBytes": 9933308,
+      "ioReadBytes": 9933308,
+      "writeDocs": 5294,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 354.94637652380953,
+      "p95Ms": 754.849021
+    },
+    {
+      "label": "mutation-measured-2-new",
+      "component": "testWorkpool",
+      "function": "worker:runMutationWrapper",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 35.435624986,
+      "p95Ms": 62.83594600000001
+    },
+    {
+      "label": "mutation-measured-2-new",
+      "component": "testWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 10765000,
+      "ioReadBytes": 10765000,
+      "writeDocs": 10000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 58.0929243804,
+      "p95Ms": 131.408557
+    },
+    {
+      "label": "mutation-measured-2-new",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 50,
+      "readDocs": 139785,
+      "readBytes": 38161256,
+      "ioReadBytes": 38161256,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 330.6231965,
+      "p95Ms": 646.996096
+    },
+    {
+      "label": "mutation-measured-2-old",
+      "component": "oldWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 80,
+      "readDocs": 30823,
+      "readBytes": 10902163,
+      "ioReadBytes": 10902163,
+      "writeDocs": 10152,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 434.2514817875,
+      "p95Ms": 580.109451
+    },
+    {
+      "label": "mutation-measured-2-old",
+      "component": "oldWorkpool",
+      "function": "worker:runMutationWrapper",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 15.393052099,
+      "p95Ms": 23.827752
+    },
+    {
+      "label": "mutation-measured-2-old",
+      "component": "oldWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 10030000,
+      "ioReadBytes": 10030000,
+      "writeDocs": 10000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 39.9427033388,
+      "p95Ms": 58.093384
+    },
+    {
+      "label": "mutation-measured-2-old",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 61,
+      "readDocs": 182368,
+      "readBytes": 49786403,
+      "ioReadBytes": 49786403,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 293.0244032622951,
+      "p95Ms": 473.055543
+    },
+    {
+      "label": "mutation-measured-3-old",
+      "component": "oldWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 80,
+      "readDocs": 30988,
+      "readBytes": 10930708,
+      "ioReadBytes": 10930708,
+      "writeDocs": 10152,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 470.738386325,
+      "p95Ms": 582.73357
+    },
+    {
+      "label": "mutation-measured-3-old",
+      "component": "oldWorkpool",
+      "function": "worker:runMutationWrapper",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 13.8183584096,
+      "p95Ms": 19.873255999999998
+    },
+    {
+      "label": "mutation-measured-3-old",
+      "component": "oldWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 10030000,
+      "ioReadBytes": 10030000,
+      "writeDocs": 10000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 40.0013815148,
+      "p95Ms": 55.161521
+    },
+    {
+      "label": "mutation-measured-3-old",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 68,
+      "readDocs": 194946,
+      "readBytes": 53220192,
+      "ioReadBytes": 53220192,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 276.3560780588235,
+      "p95Ms": 473.561405
+    },
+    {
+      "label": "mutation-measured-3-new",
+      "component": "testWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 85,
+      "readDocs": 16217,
+      "readBytes": 9067225,
+      "ioReadBytes": 9067225,
+      "writeDocs": 5291,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 315.1600237764706,
+      "p95Ms": 399.92236599999995
+    },
+    {
+      "label": "mutation-measured-3-new",
+      "component": "testWorkpool",
+      "function": "worker:runMutationWrapper",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 13.6587506456,
+      "p95Ms": 18.787502
+    },
+    {
+      "label": "mutation-measured-3-new",
+      "component": "testWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 10765000,
+      "ioReadBytes": 10765000,
+      "writeDocs": 10000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 38.7771624772,
+      "p95Ms": 48.291743999999994
+    },
+    {
+      "label": "mutation-measured-3-new",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 49,
+      "readDocs": 144574,
+      "readBytes": 39468653,
+      "ioReadBytes": 39468653,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 298.6429910612245,
+      "p95Ms": 471.961611
+    },
+    {
+      "label": "action-measured-1-old",
+      "component": "oldWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 80,
+      "readDocs": 30823,
+      "readBytes": 10847163,
+      "ioReadBytes": 10847163,
+      "writeDocs": 10152,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 425.7483263375,
+      "p95Ms": 572.547425
+    },
+    {
+      "label": "action-measured-1-old",
+      "component": null,
+      "function": "test/work:configurableAction",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 27.0957376824,
+      "p95Ms": 29.75369
+    },
+    {
+      "label": "action-measured-1-old",
+      "component": "oldWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 9865000,
+      "ioReadBytes": 9865000,
+      "writeDocs": 15000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 41.5032498868,
+      "p95Ms": 52.425485
+    },
+    {
+      "label": "action-measured-1-old",
+      "component": "oldWorkpool",
+      "function": "worker:runBatch",
+      "n": 226,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 116.49344889380531,
+      "p95Ms": 137.44403799999998
+    },
+    {
+      "label": "action-measured-1-old",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 55,
+      "readDocs": 168000,
+      "readBytes": 45527945,
+      "ioReadBytes": 45527945,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 271.07999245454545,
+      "p95Ms": 454.133053
+    },
+    {
+      "label": "action-measured-1-new",
+      "component": "testWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 83,
+      "readDocs": 16203,
+      "readBytes": 9884155,
+      "ioReadBytes": 9884155,
+      "writeDocs": 5289,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 284.0297452891566,
+      "p95Ms": 344.87104800000003
+    },
+    {
+      "label": "action-measured-1-new",
+      "component": null,
+      "function": "test/work:configurableAction",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 27.3641645278,
+      "p95Ms": 30.679698
+    },
+    {
+      "label": "action-measured-1-new",
+      "component": "testWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 10600000,
+      "ioReadBytes": 10600000,
+      "writeDocs": 15000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 42.8861220626,
+      "p95Ms": 54.650470999999996
+    },
+    {
+      "label": "action-measured-1-new",
+      "component": "testWorkpool",
+      "function": "worker:runBatch",
+      "n": 158,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 124.88785169620253,
+      "p95Ms": 156.45608099999998
+    },
+    {
+      "label": "action-measured-1-new",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 36,
+      "readDocs": 111070,
+      "readBytes": 30099934,
+      "ioReadBytes": 30099934,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 278.65986683333335,
+      "p95Ms": 462.189642
+    },
+    {
+      "label": "action-measured-2-new",
+      "component": "testWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 84,
+      "readDocs": 16210,
+      "readBytes": 9860656,
+      "ioReadBytes": 9860656,
+      "writeDocs": 5290,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 275.29697486904763,
+      "p95Ms": 315.632143
+    },
+    {
+      "label": "action-measured-2-new",
+      "component": null,
+      "function": "test/work:configurableAction",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 27.1931548568,
+      "p95Ms": 29.737452
+    },
+    {
+      "label": "action-measured-2-new",
+      "component": "testWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 10600000,
+      "ioReadBytes": 10600000,
+      "writeDocs": 15000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 41.9372139256,
+      "p95Ms": 51.582461
+    },
+    {
+      "label": "action-measured-2-new",
+      "component": "testWorkpool",
+      "function": "worker:runBatch",
+      "n": 158,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 116.88096496202532,
+      "p95Ms": 131.409673
+    },
+    {
+      "label": "action-measured-2-new",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 37,
+      "readDocs": 113697,
+      "readBytes": 30811850,
+      "ioReadBytes": 30811850,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 264.3334618918919,
+      "p95Ms": 417.99442799999997
+    },
+    {
+      "label": "action-measured-2-old",
+      "component": "oldWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 79,
+      "readDocs": 30685,
+      "readBytes": 10797209,
+      "ioReadBytes": 10797209,
+      "writeDocs": 10086,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 426.46241750632913,
+      "p95Ms": 692.601037
+    },
+    {
+      "label": "action-measured-2-old",
+      "component": null,
+      "function": "test/work:configurableAction",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 27.5963701226,
+      "p95Ms": 30.628121
+    },
+    {
+      "label": "action-measured-2-old",
+      "component": "oldWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 9865000,
+      "ioReadBytes": 9865000,
+      "writeDocs": 15000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 42.8743175576,
+      "p95Ms": 57.330701999999995
+    },
+    {
+      "label": "action-measured-2-old",
+      "component": "oldWorkpool",
+      "function": "worker:runBatch",
+      "n": 226,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 120.58574453539823,
+      "p95Ms": 168.77518899999998
+    },
+    {
+      "label": "action-measured-2-old",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 54,
+      "readDocs": 162977,
+      "readBytes": 44166714,
+      "ioReadBytes": 44166714,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 278.5757092037037,
+      "p95Ms": 585.6387159999999
+    },
+    {
+      "label": "action-measured-3-old",
+      "component": "oldWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 80,
+      "readDocs": 30931,
+      "readBytes": 10819253,
+      "ioReadBytes": 10819253,
+      "writeDocs": 10124,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 421.9712155,
+      "p95Ms": 572.882687
+    },
+    {
+      "label": "action-measured-3-old",
+      "component": null,
+      "function": "test/work:configurableAction",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 27.8108826152,
+      "p95Ms": 31.397975000000002
+    },
+    {
+      "label": "action-measured-3-old",
+      "component": "oldWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 9865000,
+      "ioReadBytes": 9865000,
+      "writeDocs": 15000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 44.42629257,
+      "p95Ms": 58.588311999999995
+    },
+    {
+      "label": "action-measured-3-old",
+      "component": "oldWorkpool",
+      "function": "worker:runBatch",
+      "n": 228,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 120.34940114912281,
+      "p95Ms": 146.879652
+    },
+    {
+      "label": "action-measured-3-old",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 55,
+      "readDocs": 169097,
+      "readBytes": 45825232,
+      "ioReadBytes": 45825232,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 296.0566932909091,
+      "p95Ms": 444.30523300000004
+    },
+    {
+      "label": "action-measured-3-new",
+      "component": "testWorkpool/batchWorker",
+      "function": "loop:loop",
+      "n": 82,
+      "readDocs": 16196,
+      "readBytes": 9909244,
+      "ioReadBytes": 9909244,
+      "writeDocs": 5288,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 284.16673641463416,
+      "p95Ms": 401.961709
+    },
+    {
+      "label": "action-measured-3-new",
+      "component": null,
+      "function": "test/work:configurableAction",
+      "n": 5000,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 38.1816069136,
+      "p95Ms": 47.444826
+    },
+    {
+      "label": "action-measured-3-new",
+      "component": "testWorkpool",
+      "function": "complete:complete",
+      "n": 5000,
+      "readDocs": 25000,
+      "readBytes": 10600000,
+      "ioReadBytes": 10600000,
+      "writeDocs": 15000,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 50.6595804904,
+      "p95Ms": 67.941904
+    },
+    {
+      "label": "action-measured-3-new",
+      "component": "testWorkpool",
+      "function": "worker:runBatch",
+      "n": 158,
+      "readDocs": 0,
+      "readBytes": 0,
+      "ioReadBytes": 0,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 172.80440097468355,
+      "p95Ms": 696.792319
+    },
+    {
+      "label": "action-measured-3-new",
+      "component": null,
+      "function": "test/run:metrics",
+      "n": 32,
+      "readDocs": 97773,
+      "readBytes": 26496451,
+      "ioReadBytes": 26496451,
+      "writeDocs": 0,
+      "errors": 0,
+      "occRetries": 0,
+      "meanMs": 337.736538625,
+      "p95Ms": 1415.7383559999998
+    }
+  ]
+}

--- a/example/benchmarks/2026-09-08.md
+++ b/example/benchmarks/2026-09-08.md
@@ -1,0 +1,245 @@
+# Design at 8186121 — benchmarks, 2026-09-08
+
+Bulk throughput improved consistently against 0.4.9: median **141 vs 113
+mutations/s** and **192 vs 134 actions/s**. All twelve measured throughput runs
+completed without timeouts or runtime execution errors. Light-load tail latency
+was variable and is assessed separately below. Keep the design for its
+bulk-throughput gain; investigate light-load tails before claiming an
+across-the-board latency improvement.
+
+Deployment: `dev:precious-raven-853`. Measured source: `8186121` on
+`ian/snapshot-ts`; the subsequent `0d80a6c` changes comments and test setup,
+with identical emitted runtime code in all changed implementation files.
+Baseline: installed `@convex-dev/workpool-old@0.4.9`. Both use
+`@convex-dev/batch-worker@0.2.1`; Convex is pinned at `1.43.0`. A further
+commit, `e94b0f3`, changed eligibility during this run. A concurrent local build
+updated `dist` at 19:13:46 PDT, after throughput and the earlier diagnostic
+checks. Whether that build was deployed could not be verified. The far-delay
+completion and light-load follow-up pairs 4–6 are therefore labeled with an
+unverified runtime revision and are not combined with the pinned comparison.
+Times below are milliseconds unless stated otherwise.
+
+The component was built and successfully deployed before measurement. The first
+push failed because the dev deployment retained `internalState.lastCommitTs`.
+After verifying all four current-code mounts had no work or pending entries, I
+backed up the state and reset the single obsolete, idle `testWorkpool` state
+row. No queued work was removed. The benchmark implementation was unchanged.
+
+## Throughput and completion latency
+
+Each arm enqueues 5,000 tasks in batches of 100 with a 50 ms inter-batch gap and
+`maxParallelism=200`. Mutations have no simulated work; actions sleep 20 ms.
+Each workload/pool gets three discarded warmups followed by three measured pairs
+in `old,new / new,old / old,new` order. All bookkeeping is archived before
+cleanup; both pools must drain and all cleanup counts must reach zero before the
+next arm.
+
+| Workload | Pool | Runs | Median tasks/s | Tasks/s range | Median total ms | Median p50 ms | Median p95 ms |
+| -------- | ---- | ---- | -------------- | ------------- | --------------- | ------------- | ------------- |
+| mutation | old  | 3    | 112.8          | 103.3–121.6   | 44,325          | 16,448        | 33,480        |
+| mutation | new  | 3    | 140.9          | 134.2–147.3   | 35,491          | 12,848        | 25,441        |
+| action   | old  | 3    | 133.7          | 132.4–135.6   | 37,408          | 13,228        | 26,525        |
+| action   | new  | 3    | 191.8          | 191.0–196.2   | 26,064          | 9,130         | 17,188        |
+
+Mutation throughput ratios (new/old) by pair: **1.364×, 1.104×, 1.306×**; median
+**1.306×** (+30.6%).
+
+Action throughput ratios (new/old) by pair: **1.429×, 1.447×, 1.449×**; median
+**1.447×** (+44.7%).
+
+Individual measured runs:
+
+| Workload | Pair | Pool | Total ms | Tasks/s | p95 ms | Enqueue ms |
+| -------- | ---- | ---- | -------- | ------- | ------ | ---------- |
+| mutation | 1    | old  | 48417    | 103.3   | 37140  | 9056       |
+| mutation | 1    | new  | 35491    | 140.9   | 25441  | 8651       |
+| mutation | 2    | new  | 37250    | 134.2   | 27162  | 9065       |
+| mutation | 2    | old  | 41108    | 121.6   | 30669  | 8968       |
+| mutation | 3    | old  | 44325    | 112.8   | 33480  | 9292       |
+| mutation | 3    | new  | 33935    | 147.3   | 24661  | 8167       |
+| action   | 1    | old  | 37408    | 133.7   | 26525  | 9593       |
+| action   | 1    | new  | 26175    | 191.0   | 17188  | 7942       |
+| action   | 2    | new  | 25483    | 196.2   | 17160  | 7374       |
+| action   | 2    | old  | 36862    | 135.6   | 25835  | 9080       |
+| action   | 3    | old  | 37767    | 132.4   | 27858  | 8370       |
+| action   | 3    | new  | 26064    | 191.8   | 17485  | 7751       |
+
+Completion latency is enqueue → terminal callback, including work and recorder
+overhead. These are medians of run-level percentiles, not pooled task
+percentiles. Three pairs give descriptive evidence, not a precise confidence
+interval. The comparison includes all differences between this design and 0.4.9;
+it does not isolate the snapshot change alone. Separate component storage
+histories remain a confound.
+
+## Light-load completion latency
+
+3 pairs of 20 waves × one 50 ms action, 500 ms between waves, at
+parallelism 200. These are paced latency checks, not saturation throughput.
+These initial pairs ran before the concurrent build. No separate light-load
+warmup was discarded; this is a latency diagnostic, not a stable p95 estimate.
+
+| Pool | Runs | Median p50 ms | Median p95 ms | Individual p95 ms |
+| ---- | ---- | ------------- | ------------- | ----------------- |
+| old  | 3    | 247.0         | 604.0         | 1132, 604, 350    |
+| new  | 3    | 288.0         | 1430.0        | 1604, 443, 1430   |
+
+The new pool’s median run-level p95 was higher, but individual results varied
+widely (443–1,604 ms new, 350–1,132 ms old). Some slow runs also stretched the
+identical 50 ms action itself. Repeat with more samples and use the same
+component for a source comparison before attributing this to the design.
+
+Follow-up pairs 4–6 were added to investigate the variation. They ran after the
+concurrent local build, so the runtime revision is unverified. They are retained
+as observations and excluded from the pinned summary above.
+
+| Pair | Pool | p50 ms | p95 ms |
+| ---- | ---- | ------ | ------ |
+| 4    | new  | 261    | 1158   |
+| 4    | old  | 244    | 361    |
+| 5    | old  | 265    | 1160   |
+| 5    | new  | 221    | 440    |
+| 6    | new  | 272    | 347    |
+| 6    | old  | 253    | 346    |
+
+## Start latency and scheduling checks
+
+These are paired smoke/diagnostic runs, not repeated performance estimates.
+Every cell uses parallelism 200 unless specified otherwise.
+
+Mixed cell: 600 tasks delayed 3 seconds, then 2,000 immediate tasks; chunk
+size 25. Values are start lateness relative to each task’s due time.
+
+| Pool | Delay ms | Started | p50 ms | p95 ms | Min ms | Max ms | Early starts |
+| ---- | -------- | ------- | ------ | ------ | ------ | ------ | ------------ |
+| old  | 0        | 2000    | 909    | 2144   | 502    | 2558   | 0            |
+| old  | 3000     | 600     | 263    | 2192   | 68     | 2415   | 0            |
+| new  | 0        | 2000    | 618    | 1077   | 346    | 2624   | 0            |
+| new  | 3000     | 600     | 317    | 1901   | 126    | 2079   | 0            |
+
+Sibling checks: 12 enqueue transactions, a 200 ms delayed sibling, and 800
+nested no-op calls per enqueue. Concurrent traffic supplies 1,000 immediate
+probes in single-task chunks at 100 ms gaps. The same traffic continues through
+the backlog case.
+
+| Pool | Pairs | Overdue at RPC return | Median scheduled − immediate ms | p95 difference ms | Min ms | Max ms | Missing |
+| ---- | ----- | --------------------- | ------------------------------- | ----------------- | ------ | ------ | ------- |
+| old  | 12    | 12                    | 0                               | 3                 | -1     | 3      | 0       |
+| new  | 12    | 12                    | 0                               | 5                 | -2     | 5      | 0       |
+
+RPC-return time is only an upper bound on commit time. Concurrent traffic
+creates opportunities for cursor advancement; no direct sweep instrumentation
+was added, so these results do not independently prove which path rescued each
+task.
+
+Backlog checks: 2,000 tasks delayed 60 seconds in one batch, then one 100 ms
+delayed/immediate pair with 800 nested calls. After the pair returned, the
+driver waited for all bulk/background work and verified every bulk probe started
+before cleanup.
+
+| Pool | Pair enqueue RPC ms | Scheduled lateness ms | Immediate lateness ms | Scheduled − immediate ms | Scheduled started |
+| ---- | ------------------- | --------------------- | --------------------- | ------------------------ | ----------------- |
+| old  | 1622                | 2661                  | 2963                  | -202                     | True              |
+| new  | 1577                | 1622                  | 1722                  | 0                        | True              |
+
+Delayed/retry checks use only the new pool at parallelism 10. The 310-second
+case crosses the five-minute scan-index cutoff. The harness records its origin
+outside the enqueue transaction. The driver also read the pending queue key
+during the wait, verifying scan-index presence/absence and measuring start
+lateness against the actual stored due time.
+
+| Delay ms | Ran  | Early | Harness lateness ms | Lateness from stored key ms | Has scanTs | Retry attempts |
+| -------- | ---- | ----- | ------------------- | --------------------------- | ---------- | -------------- |
+| 8000     | True | False | 120                 | 118                         | True       | 3              |
+| 310000   | True | False | —                   | 365                         | False      | 3              |
+
+The 310-second CLI call returned a generic error instead of JSON. The persisted
+delayed/retry probes, an empty workpool, and the server action’s completion log
+(313.46 seconds, no error) confirmed completion. The exact stored due time had
+already been captured, so lateness could be recovered without enqueueing another
+run. The CLI failure’s cause was not established. This completion occurred after
+the concurrent local build, so the worker’s runtime revision is unverified; it
+is not a certified result for `8186121`.
+
+## Mixed-action checks
+
+One run per pool/preset at parallelism 40: `slowNeighbor` mixes 28 × 50 ms
+actions with four × 20-second actions; `failRetry` mixes 24 successes with eight
+failures allowed three attempts. Outcomes were explicitly checked.
+
+| Preset       | Pool | Class | Count | Terminal outcomes | p50 ms | p95 ms |
+| ------------ | ---- | ----- | ----- | ----------------- | ------ | ------ |
+| slowNeighbor | old  | fast  | 28    | {"success": 28}   | 122    | 131    |
+| slowNeighbor | old  | slow  | 4     | {"success": 4}    | 20107  | 20171  |
+| slowNeighbor | new  | fast  | 28    | {"success": 28}   | 214    | 215    |
+| slowNeighbor | new  | slow  | 4     | {"success": 4}    | 20213  | 20247  |
+| failRetry    | old  | fail  | 8     | {"failed": 8}     | 1365   | 1894   |
+| failRetry    | old  | fast  | 24    | {"success": 24}   | 110    | 118    |
+| failRetry    | new  | fail  | 8     | {"failed": 8}     | 1989   | 1990   |
+| failRetry    | new  | fast  | 24    | {"success": 24}   | 265    | 266    |
+
+## Runtime evidence
+
+Median across measured runs, from each pool’s nested `batchWorker` loop:
+
+| Workload | Pool | Mean loop execution ms | Loop document reads/run | Loop document writes/run |
+| -------- | ---- | ---------------------- | ----------------------- | ------------------------ |
+| mutation | old  | 470.7                  | 30,917                  | 10,152                   |
+| mutation | new  | 315.2                  | 16,224                  | 5,292                    |
+| action   | old  | 425.7                  | 30,823                  | 10,124                   |
+| action   | new  | 284.0                  | 16,203                  | 5,289                    |
+
+The reduction in loop work is consistent with the throughput improvement. This
+is supporting evidence, not an isolated causal test of a single source change.
+Progress polling itself read roughly 98,000–195,000 task rows per measured
+5,000-task run (about 26–53 MB), exceeding the loop’s reads. These measurements
+include that harness load.
+
+## Evidence and limits
+
+Raw outputs, exact arguments, run metadata, state backup, runtime logs, and the
+one-off drivers are in `.context/benchmark-2026-09-08/`. `runs.jsonl` includes
+discarded warmups; `checks.jsonl` contains the diagnostic results. These raw
+artifacts are local and gitignored. This report and
+[compact JSON results](./2026-09-08.json) live under `example/benchmarks/` for
+version control; the JSON preserves metadata, all throughput outputs including
+warmups, diagnostic summaries, and selected execution statistics.
+
+Preflight: 148 tests in 14 files passed, with no type errors, for the measured
+implementation (including the equivalent `0d80a6c` test/comment refinement).
+Final checks found zero work, pending entries, payloads, and running jobs in
+both pools; app bookkeeping counts were also zero. Both pools were left at
+parallelism 200. Runtime logs contained only the expected 48 noisy-action errors
+and four deliberate retry errors. The long-delay CLI error is recorded above
+separately from server function results.
+
+The ordinary throughput recorder does not retain outcome kind. Exact callback
+counts and no timeout are necessary checks, but success/error evidence must also
+come from runtime logs. Intentional worker errors in the retry scenarios are
+expected.
+
+## What belongs in code, and what belongs in the guide
+
+Keep `BENCHMARKS.md`, but make its eventual job metric definitions and
+experiment interpretation. Most operational instructions are compensating for
+missing harness behavior and should become executable checks. I corrected the
+guide now; the backend and dashboard improvements below are recommendations, not
+changes made during this measurement.
+
+| Priority | Finding                                                                                                                                                                                                                                                                | Recommendation                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1        | The deploy command omitted the build, although component exports point at `dist`. The actual first push also failed on the removed `lastCommitTs` field in persisted experimental state.                                                                               | A checked-in `npm run bench` should build, require a successful deploy, and record the deployed component fingerprint/versions before each run, and reject runs across a fingerprint change. A concurrent build during this session made the late follow-up revision uncertain. Use an isolated checkout/deployment for a comparison. Provide an explicit compatibility migration or guarded reset for obsolete experimental state; avoid permanent instructions to manually edit data. |
+| 1        | `completedCount` counts callbacks, even failed/canceled tasks. Timeouts can return JSON normally, giving CLI exit code zero. The ordinary recorder discards `result.kind`, although the schema already supports it.                                                    | Persist terminal outcomes and work IDs, require exactly the expected unique successful tasks, return a run handle early with structured failure/timeout status, and make the runner fail on invalid results. Resume that handle after transport errors instead of repeating enqueues; the 310-second CLI call failed even though the server completed. Expected failures in noisy-neighbor tests should have explicit assertions.                                                       |
+| 1        | Cleanup deletes all run history and several shared app tables, but does not drain either component or clear `counters`. `backlog` can return with 2,000 delayed tasks still queued; resetting a cell can delete rows while its old workers remain active.              | A runner should own a run/cell, wait for all its work and callbacks to settle, archive results, and clean up only that run. Make `run.start` check active runs per pool instead of only the latest global run. Have `backlog` wait for its bulk or return an explicit outstanding-work handle. Expose drain/cleanup status instead of requiring manual polling.                                                                                                                         |
+| 1        | Main instructions depended on gitignored `.context` scripts. The shell driver has one discarded pair rather than three per workload, filters away raw JSON, can mask errors through a pipeline, and continues after cleanup failure.                                   | Check in a runner with explicit warmup/repetition counts, balanced serial order, bounded waits, error propagation, raw JSON output, metadata, and per-pair summaries. No ad hoc regex parsing of human logs.                                                                                                                                                                                                                                                                            |
+| 2        | The mutation example claimed 20 ms of work, but `taskDurationMs` is action-only. Both stored parameters and printed messages preserve the misleading value.                                                                                                            | Validate arguments by workload type and report effective parameters. Make mutation work explicit in operations/bytes; do not simulate it with a frozen wall-clock spin loop.                                                                                                                                                                                                                                                                                                            |
+| 2        | `pairs`/`backlog` examples do not supply their necessary concurrent traffic. `committedAt` is RPC-return time, and the scheduling smoke test measures its due time from outside the enqueuing mutation. The latter only records attempts, not the final retry outcome. | Make cursor experiments self-contained with bounded ready traffic and proof that the intended cursor condition occurred. Record actual `runAt` inside the enqueue transaction, distinguish commit timestamp from RPC-return time, and assert delayed-start and terminal retry outcomes. Keep clock/metric definitions in the guide.                                                                                                                                                     |
+| 2        | The documented 2,000-task backlog now packs into eight pending-start documents; the sweep budget is 256 documents. Its old `SWEEP_BATCH` comment describes a different implementation.                                                                                 | Add a fixture with enough distinct scheduled keys to exceed the document budget, and assert the actual document count/commit grouping. Keep the existing packed backlog as a smoke check.                                                                                                                                                                                                                                                                                               |
+| 2        | Repeated metrics polling collects every task in the run, so measurement overhead grows with completed count. Larger tests also approach query limits. `sustained` ignores rejected enqueue promises from `Promise.allSettled`.                                         | Check every enqueue outcome. Use bounded progress queries or a completion signal while waiting; calculate full quantiles once from archived/paginated rows. Avoid introducing a single contended per-task counter in the measured path.                                                                                                                                                                                                                                                 |
+| 3        | The constant-editing script is not generally mirrored as described and `git checkout` can overwrite concurrent edits. Three warmups are only a heuristic.                                                                                                              | Use isolated checkouts and an explicit experiment matrix. Keep warmup drift, paired comparisons, storage-history confounds, and noise-floor interpretation in documentation. These cannot be removed by changing pool functions.                                                                                                                                                                                                                                                        |
+| 3        | Claims that non-monotonic results must be noise, that all workers from one enqueue share a start time, and that higher execution time with fewer reads proves round trips were too strong or wrong.                                                                    | Keep corrected methodology in the guide: transactions share an enqueue clock/commit, worker starts differ, nonlinear optima can be real, and round trips are one hypothesis to investigate.                                                                                                                                                                                                                                                                                             |
+| 3        | The example README and four dashboard labels still said 0.4.7; the installed baseline is 0.4.9. Both mounts now have nested `batchWorker` components, so earlier 0.4.7 scheduler-count comparisons are not current evidence.                                           | Report the mounted package version in benchmark metadata and drive UI labels from it. Count nested loop components consistently. Date/version historical reports instead of treating them as current results.                                                                                                                                                                                                                                                                           |
+
+The guide was updated to remove workspace scripts from the supported procedure,
+correct the build step and metric definitions, inventory current harnesses, and
+explain the limits found above. The example README's baseline description was
+also corrected. No workpool implementation or benchmark function was changed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "chokidar-cli": "3.0.0",
         "convex": "1.43.0",
         "convex-helpers": "0.1.111",
-        "convex-test": "0.0.55",
+        "convex-test": "https://pkg.pr.new/convex-test@139",
         "eslint": "10.0.2",
         "eslint-plugin-react-hooks": "7.1.0-canary-3f0b9e61-20260317",
         "eslint-plugin-react-refresh": "0.5.0",
@@ -3139,9 +3139,9 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.55",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.55.tgz",
-      "integrity": "sha512-ablJ6vR3WUpyTaYrrRQf8yxInGrhHyqBEQsCFzloda3G0MDEu2RMKNGUkvlBXYWPiiEP0UIKPS7gZuLbqGnvQw==",
+      "version": "0.0.56",
+      "resolved": "https://pkg.pr.new/convex-test@139",
+      "integrity": "sha512-U1bg51ELewwQ1FeA0Y6DZsH7+GOo+TFY6kJnuobtaAbaZ3w1eUXi11CuC6ZyxHBp39Vby0XigltONdof878lyA==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "chokidar-cli": "3.0.0",
         "convex": "1.43.0",
         "convex-helpers": "0.1.111",
-        "convex-test": "https://pkg.pr.new/convex-test@139",
+        "convex-test": "^0.0.57-alpha.0",
         "eslint": "10.0.2",
         "eslint-plugin-react-hooks": "7.1.0-canary-3f0b9e61-20260317",
         "eslint-plugin-react-refresh": "0.5.0",
@@ -3139,9 +3139,9 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.56",
-      "resolved": "https://pkg.pr.new/convex-test@139",
-      "integrity": "sha512-U1bg51ELewwQ1FeA0Y6DZsH7+GOo+TFY6kJnuobtaAbaZ3w1eUXi11CuC6ZyxHBp39Vby0XigltONdof878lyA==",
+      "version": "0.0.57-alpha.0",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.57-alpha.0.tgz",
+      "integrity": "sha512-dTR6S4HTGwcETapH0zfmaHb81PuvIScF2pRBFgpjPXOOuErSrSF5uZT7SRYrbNCDO6jBuxkZH2RNVMK9a0GQtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "chokidar-cli": "3.0.0",
     "convex": "1.43.0",
     "convex-helpers": "0.1.111",
-    "convex-test": "0.0.55",
+    "convex-test": "https://pkg.pr.new/convex-test@139",
     "eslint": "10.0.2",
     "eslint-plugin-react-hooks": "7.1.0-canary-3f0b9e61-20260317",
     "eslint-plugin-react-refresh": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "chokidar-cli": "3.0.0",
     "convex": "1.43.0",
     "convex-helpers": "0.1.111",
-    "convex-test": "https://pkg.pr.new/convex-test@139",
+    "convex-test": "^0.0.57-alpha.0",
     "eslint": "10.0.2",
     "eslint-plugin-react-hooks": "7.1.0-canary-3f0b9e61-20260317",
     "eslint-plugin-react-refresh": "0.5.0",

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -22,7 +22,9 @@ import {
   vOnCompleteFnContext,
   retryBehavior,
   status as statusValidator,
+  maxBigint,
   MINUTE,
+  snapshotTs,
   toTimestamp,
 } from "./shared.js";
 import { recordEnqueued } from "./stats.js";
@@ -137,19 +139,27 @@ const MAX_PACKED = 256;
  *
  * Ready-now entries are ordered by this transaction's commit timestamp, which
  * can't land behind the loop's cursor. Scheduled entries are ordered by their
- * start time, invisible to the loop until due — but such a document could
- * commit *behind* the cursor (if the enqueue takes longer to commit than the
- * delay), so it also records its commit stamp in `scanTs`; the loop sweeps
- * that index in commit order and starts anything the cursor passed over.
+ * start time, ineligible until the loop's snapshot reaches it — but such a
+ * document could commit *behind* the cursor (if the enqueue takes longer to
+ * commit than the delay), so it also records its commit stamp in `scanTs`; the
+ * loop sweeps that index in commit order and starts anything the cursor passed
+ * over.
+ *
+ * No key is ever below its writer's snapshot: the commit stamp is above it by
+ * definition, and a start time the commit clock has already passed is raised
+ * to it (as the loop does for the keys it writes). So an entry can only land
+ * behind the cursor by committing while the loop was mid-iteration, never by
+ * the wall clock trailing the commit clock.
  */
 async function insertPendingStarts(
   ctx: MutationCtx,
   entries: { workId: Id<"work">; runAt: number }[],
 ) {
   const now = Date.now();
+  const floor = snapshotTs();
   const groups = new Map<bigint | "now", Id<"work">[]>();
   for (const { workId, runAt } of entries) {
-    const key = runAt > now ? toTimestamp(runAt) : "now";
+    const key = runAt > now ? maxBigint(toTimestamp(runAt), floor) : "now";
     const group = groups.get(key);
     if (group) group.push(workId);
     else groups.set(key, [workId]);

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -139,9 +139,8 @@ const MAX_PACKED = 256;
  * can't land behind the loop's cursor. Scheduled entries are ordered by their
  * start time, invisible to the loop until due — but such a document could
  * commit *behind* the cursor (if the enqueue takes longer to commit than the
- * delay), so it's marked `scheduled` and records its commit stamp in
- * `scanTs`; the loop sweeps that index in commit order and starts anything
- * the cursor passed over.
+ * delay), so it also records its commit stamp in `scanTs`; the loop sweeps
+ * that index in commit order and starts anything the cursor passed over.
  */
 async function insertPendingStarts(
   ctx: MutationCtx,
@@ -196,7 +195,6 @@ async function insertPendingStarts(
       const pendingStartId = await ctx.db.insert("pendingStart", {
         workIds: chunk,
         segment: key === "now" ? ctx.db.vars.commitTs : key,
-        ...(key === "now" ? {} : { scheduled: true }),
         ...(key !== "now" && key <= scanCutoff
           ? { scanTs: ctx.db.vars.commitTs }
           : {}),

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -139,17 +139,11 @@ const MAX_PACKED = 256;
  *
  * Ready-now entries are ordered by this transaction's commit timestamp, which
  * can't land behind the loop's cursor. Scheduled entries are ordered by their
- * start time, ineligible until the loop's snapshot reaches it — but such a
- * document could commit *behind* the cursor (if the enqueue takes longer to
- * commit than the delay), so it also records its commit stamp in `scanTs`; the
- * loop sweeps that index in commit order and starts anything the cursor passed
- * over.
- *
- * No key is ever below its writer's snapshot: the commit stamp is above it by
- * definition, and a start time the commit clock has already passed is raised
- * to it (as the loop does for the keys it writes). So an entry can only land
- * behind the cursor by committing while the loop was mid-iteration, never by
- * the wall clock trailing the commit clock.
+ * start time, raised to this transaction's snapshot if the commit clock is
+ * already past it, so no key is ever below its writer's snapshot. Such a
+ * document can still commit *behind* the cursor (if the enqueue takes longer to
+ * commit than the delay), so it also records its commit stamp in `scanTs` for
+ * the loop's sweep.
  */
 async function insertPendingStarts(
   ctx: MutationCtx,

--- a/src/component/loop.test.ts
+++ b/src/component/loop.test.ts
@@ -1,4 +1,5 @@
 import type { WithoutSystemFields } from "convex/server";
+import { convexToJson } from "convex/values";
 import {
   afterEach,
   assert,
@@ -139,6 +140,34 @@ describe("loop", () => {
       await t.mutation(internal.loop.run, result.batch);
     }
     return result;
+  }
+
+  /**
+   * Run `fn` with the snapshot-timestamp syscall answering `ts` instead of
+   * convex-test's real value — e.g. to simulate the commit clock lagging the
+   * wall clock. Safe as long as `ts` is at or below the real one.
+   */
+  async function withSnapshotTs<T>(ts: bigint, fn: () => Promise<T>) {
+    type Syscall = (op: string, args: string) => string;
+    const convex = (globalThis as unknown as { Convex: object }).Convex;
+    // convex-test defines `syscall` as a getter resolving the current test's
+    // context; wrap what it resolves to rather than replacing it.
+    const original = Object.getOwnPropertyDescriptor(convex, "syscall")!;
+    Object.defineProperty(convex, "syscall", {
+      configurable: true,
+      get: (): Syscall => {
+        const real = original.get!.call(convex) as Syscall;
+        return (op, args) =>
+          op === "1.0/getSnapshotTs"
+            ? JSON.stringify(convexToJson(ts))
+            : real(op, args);
+      },
+    });
+    try {
+      return await fn();
+    } finally {
+      Object.defineProperty(convex, "syscall", original);
+    }
   }
 
   /** Pretend a worker finished a job by inserting pendingCompletion. */
@@ -840,8 +869,8 @@ describe("loop", () => {
       // One document for the four ready entries, one for the scheduled one.
       let o = await observe();
       expect(o.pendingStart).toHaveLength(2);
-      const ready = o.pendingStart.find((p) => p.scheduled === undefined)!;
-      const scheduled = o.pendingStart.find((p) => p.scheduled === true)!;
+      const ready = o.pendingStart.find((p) => p.scanTs === undefined)!;
+      const scheduled = o.pendingStart.find((p) => p.scanTs !== undefined)!;
       expect(ready.workIds).toEqual(ids.slice(0, 4));
       expect(scheduled.workIds).toEqual([ids[4]]);
       expect(scheduled.segment).toBe(toTimestamp(runAt));
@@ -886,7 +915,6 @@ describe("loop", () => {
         const pendingStartId = await ctx.db.insert("pendingStart", {
           workIds: [workId],
           segment: cursor - 1n,
-          scheduled: true,
           scanTs: ctx.db.vars.commitTs,
         });
         await ctx.db.patch("work", workId, { pendingStartId });
@@ -963,7 +991,6 @@ describe("loop", () => {
         const pendingStartId = await ctx.db.insert("pendingStart", {
           workIds: ids,
           segment: cursor - 1n,
-          scheduled: true,
           scanTs: ctx.db.vars.commitTs,
         });
         await Promise.all(
@@ -997,20 +1024,28 @@ describe("loop", () => {
       expect((await observe()).pendingStart).toHaveLength(0);
     });
 
-    it("caps the cursor at observed commit stamps when starting wall-keyed work", async () => {
+    it("caps the cursor at the snapshot when starting wall-keyed work", async () => {
       await initialize();
       const runAt = Date.now() + SECOND;
       const workId = await enqueueWork({}, { runAt });
       await runLoop(); // sweep verifies the entry
       vi.advanceTimersByTime(SECOND);
-      await runLoop(); // starts it, keyed at its start time
+      // The commit clock lags the wall clock: this run's snapshot sits below
+      // the entry's wall-clock key, though the key is due.
+      const snapshot = toTimestamp(runAt) - toTimestamp(SECOND) / 2n;
+      await withSnapshotTs(snapshot, () => runLoop()); // starts it
 
       const o = await observe();
       expect(o.running.map((r) => r.workId)).toEqual([workId]);
-      // The cursor stops at the freshest commit stamp this run had seen, not
-      // at the wall-clock key: a commit racing this iteration could land
-      // below that key, and nothing relates the two clocks.
-      expect(o.segmentCursors!.incoming).toBeLessThan(toTimestamp(runAt));
+      // The cursor stops at the snapshot, not at the wall-clock key: a commit
+      // racing this iteration could land between the two, and nothing relates
+      // the two clocks.
+      expect(o.segmentCursors!.incoming).toBe(snapshot);
+
+      // Work committing after that snapshot is still found.
+      const laterId = await enqueueWork();
+      await runLoop();
+      expect((await observe()).running.map((r) => r.workId)).toContain(laterId);
     });
   });
 

--- a/src/component/loop.test.ts
+++ b/src/component/loop.test.ts
@@ -130,12 +130,8 @@ describe("loop", () => {
    * Drive one loop iteration the way batch-worker does: get the next batch,
    * and if there's work, run the worker mutation with it. Returns the batch
    * result so tests can inspect the idle/work decision.
-   *
-   * Starts with an empty commit so the fake clock reaches convex-test's
-   * snapshot, which only advances on commit.
    */
   async function runLoop() {
-    await t.run(async () => {});
     const result = await t.query(internal.loop.getBatch, {
       name: WORKER_NAME,
     });
@@ -999,28 +995,27 @@ describe("loop", () => {
       expect((await observe()).pendingStart).toHaveLength(0);
     });
 
-    it("makes scheduled work due by the commit clock, not the wall clock", async () => {
+    it("caps the cursor at the snapshot when starting wall-keyed work", async () => {
       await initialize();
       const runAt = Date.now() + SECOND;
       const workId = await enqueueWork({}, { runAt });
       await runLoop(); // sweep verifies the entry
+      // Nothing commits between here and the read, so the snapshot stays
+      // below the key while the wall clock says it's due.
       vi.advanceTimersByTime(SECOND);
+      await runLoop();
 
-      // The wall clock says due, but nothing has committed since it advanced,
-      // so the snapshot hasn't reached the key: the entry is left alone and the
-      // cursor stays below it.
-      const held = await t.query(internal.loop.getBatch, { name: WORKER_NAME });
-      expect(held.kind).toBe("idle");
       let o = await observe();
-      expect(o.running).toHaveLength(0);
+      expect(o.running.map((r) => r.workId)).toEqual([workId]);
+      // The cursor stops at the snapshot, not the wall-clock key: a commit
+      // racing this iteration could land between the two.
       expect(o.segmentCursors!.incoming).toBeLessThan(toTimestamp(runAt));
 
-      // A commit carries the snapshot past the key: the entry starts and the
-      // cursor rests on it.
+      // Work committing after that snapshot is still found.
+      const laterId = await enqueueWork();
       await runLoop();
       o = await observe();
-      expect(o.running.map((r) => r.workId)).toEqual([workId]);
-      expect(o.segmentCursors!.incoming).toBe(toTimestamp(runAt));
+      expect(o.running.map((r) => r.workId)).toContain(laterId);
     });
   });
 

--- a/src/component/loop.test.ts
+++ b/src/component/loop.test.ts
@@ -1,5 +1,4 @@
 import type { WithoutSystemFields } from "convex/server";
-import { convexToJson } from "convex/values";
 import {
   afterEach,
   assert,
@@ -132,10 +131,8 @@ describe("loop", () => {
    * and if there's work, run the worker mutation with it. Returns the batch
    * result so tests can inspect the idle/work decision.
    *
-   * Starts with an empty commit. The loop's eligibility bound is its snapshot
-   * timestamp, which in convex-test is the latest commit, so an advance of the
-   * fake clock has to reach the database the way batch-worker's own commits do
-   * in production before scheduled work can come due.
+   * Starts with an empty commit so the fake clock reaches convex-test's
+   * snapshot, which only advances on commit.
    */
   async function runLoop() {
     await t.run(async () => {});
@@ -146,34 +143,6 @@ describe("loop", () => {
       await t.mutation(internal.loop.run, result.batch);
     }
     return result;
-  }
-
-  /**
-   * Run `fn` with the snapshot-timestamp syscall answering `ts` instead of
-   * convex-test's real value — e.g. to simulate the commit clock lagging the
-   * wall clock. Safe as long as `ts` is at or below the real one.
-   */
-  async function withSnapshotTs<T>(ts: bigint, fn: () => Promise<T>) {
-    type Syscall = (op: string, args: string) => string;
-    const convex = (globalThis as unknown as { Convex: object }).Convex;
-    // convex-test defines `syscall` as a getter resolving the current test's
-    // context; wrap what it resolves to rather than replacing it.
-    const original = Object.getOwnPropertyDescriptor(convex, "syscall")!;
-    Object.defineProperty(convex, "syscall", {
-      configurable: true,
-      get: (): Syscall => {
-        const real = original.get!.call(convex) as Syscall;
-        return (op, args) =>
-          op === "1.0/getSnapshotTs"
-            ? JSON.stringify(convexToJson(ts))
-            : real(op, args);
-      },
-    });
-    try {
-      return await fn();
-    } finally {
-      Object.defineProperty(convex, "syscall", original);
-    }
   }
 
   /** Pretend a worker finished a job by inserting pendingCompletion. */
@@ -1037,19 +1006,17 @@ describe("loop", () => {
       await runLoop(); // sweep verifies the entry
       vi.advanceTimersByTime(SECOND);
 
-      // The wall clock says due, but the snapshot hasn't reached the key: the
-      // entry is left alone, and the cursor stays below it. Advancing to the
-      // wall-clock key here would let a commit stamped between the two clocks
-      // land behind the cursor.
-      const early = toTimestamp(runAt) - 1n;
-      const held = await withSnapshotTs(early, () => runLoop());
+      // The wall clock says due, but nothing has committed since it advanced,
+      // so the snapshot hasn't reached the key: the entry is left alone and the
+      // cursor stays below it.
+      const held = await t.query(internal.loop.getBatch, { name: WORKER_NAME });
       expect(held.kind).toBe("idle");
       let o = await observe();
       expect(o.running).toHaveLength(0);
       expect(o.segmentCursors!.incoming).toBeLessThan(toTimestamp(runAt));
 
-      // Once the snapshot passes the key, the entry starts and the cursor can
-      // rest on it: nothing committing later is stamped at or below it.
+      // A commit carries the snapshot past the key: the entry starts and the
+      // cursor rests on it.
       await runLoop();
       o = await observe();
       expect(o.running.map((r) => r.workId)).toEqual([workId]);
@@ -1074,9 +1041,8 @@ describe("loop", () => {
       });
       await runLoop();
       await simulateCompletion(workId, { kind: "failed", error: "boom" }, 0);
-      // A ready entry enqueued after the completion: its commit timestamp is
-      // above the retry's `Date.now()`-derived one, so a cursor advancing to
-      // it in the same iteration would strand a retry keyed by the wall clock.
+      // A ready entry enqueued after the completion sorts above a wall-clock
+      // retry key, so a cursor advancing to it would strand the retry.
       const laterId = await enqueueWork();
 
       await runLoop();

--- a/src/component/loop.test.ts
+++ b/src/component/loop.test.ts
@@ -131,8 +131,14 @@ describe("loop", () => {
    * Drive one loop iteration the way batch-worker does: get the next batch,
    * and if there's work, run the worker mutation with it. Returns the batch
    * result so tests can inspect the idle/work decision.
+   *
+   * Starts with an empty commit. The loop's eligibility bound is its snapshot
+   * timestamp, which in convex-test is the latest commit, so an advance of the
+   * fake clock has to reach the database the way batch-worker's own commits do
+   * in production before scheduled work can come due.
    */
   async function runLoop() {
+    await t.run(async () => {});
     const result = await t.query(internal.loop.getBatch, {
       name: WORKER_NAME,
     });
@@ -1024,28 +1030,30 @@ describe("loop", () => {
       expect((await observe()).pendingStart).toHaveLength(0);
     });
 
-    it("caps the cursor at the snapshot when starting wall-keyed work", async () => {
+    it("makes scheduled work due by the commit clock, not the wall clock", async () => {
       await initialize();
       const runAt = Date.now() + SECOND;
       const workId = await enqueueWork({}, { runAt });
       await runLoop(); // sweep verifies the entry
       vi.advanceTimersByTime(SECOND);
-      // The commit clock lags the wall clock: this run's snapshot sits below
-      // the entry's wall-clock key, though the key is due.
-      const snapshot = toTimestamp(runAt) - toTimestamp(SECOND) / 2n;
-      await withSnapshotTs(snapshot, () => runLoop()); // starts it
 
-      const o = await observe();
-      expect(o.running.map((r) => r.workId)).toEqual([workId]);
-      // The cursor stops at the snapshot, not at the wall-clock key: a commit
-      // racing this iteration could land between the two, and nothing relates
-      // the two clocks.
-      expect(o.segmentCursors!.incoming).toBe(snapshot);
+      // The wall clock says due, but the snapshot hasn't reached the key: the
+      // entry is left alone, and the cursor stays below it. Advancing to the
+      // wall-clock key here would let a commit stamped between the two clocks
+      // land behind the cursor.
+      const early = toTimestamp(runAt) - 1n;
+      const held = await withSnapshotTs(early, () => runLoop());
+      expect(held.kind).toBe("idle");
+      let o = await observe();
+      expect(o.running).toHaveLength(0);
+      expect(o.segmentCursors!.incoming).toBeLessThan(toTimestamp(runAt));
 
-      // Work committing after that snapshot is still found.
-      const laterId = await enqueueWork();
+      // Once the snapshot passes the key, the entry starts and the cursor can
+      // rest on it: nothing committing later is stamped at or below it.
       await runLoop();
-      expect((await observe()).running.map((r) => r.workId)).toContain(laterId);
+      o = await observe();
+      expect(o.running.map((r) => r.workId)).toEqual([workId]);
+      expect(o.segmentCursors!.incoming).toBe(toTimestamp(runAt));
     });
   });
 
@@ -1068,7 +1076,7 @@ describe("loop", () => {
       await simulateCompletion(workId, { kind: "failed", error: "boom" }, 0);
       // A ready entry enqueued after the completion: its commit timestamp is
       // above the retry's `Date.now()`-derived one, so a cursor advancing to
-      // it in the same iteration would strand a same-millisecond retry key.
+      // it in the same iteration would strand a retry keyed by the wall clock.
       const laterId = await enqueueWork();
 
       await runLoop();
@@ -1076,35 +1084,27 @@ describe("loop", () => {
       expect(o.running.map((r) => r.workId)).toEqual([laterId]);
       const retry = o.pendingStart.find((p) => p.workIds?.includes(workId));
       assert(retry);
+      // Raised to the snapshot instead, so it's eligible next iteration.
       expect(retry.segment).toBeGreaterThanOrEqual(o.segmentCursors!.incoming);
-
-      // Keyed at the next millisecond, so it starts as soon as that arrives.
-      vi.advanceTimersByTime(1);
       await runLoop();
       o = await observe();
       expect(o.pendingStart).toHaveLength(0);
       expect(o.running.map((r) => r.workId)).toContain(workId);
     });
 
-    it("keys a sub-millisecond runAt to the next whole millisecond", async () => {
+    it("keeps a sub-millisecond runAt exact and starts it within a millisecond", async () => {
       await initialize();
-      // Truncated to whole milliseconds this `runAt` would be readable while
-      // `isDue` still says no; rounded up, it's invisible until the first
-      // millisecond the clock can call it due.
       const runAt = Date.now() + 0.5;
       const workId = await enqueueWork({}, { runAt });
-      const readyId = await enqueueWork();
-
-      await runLoop();
-      const o = await observe();
-      expect(o.running.map((r) => r.workId)).toEqual([readyId]);
-      const entry = o.pendingStart.find((p) => p.workIds?.includes(workId));
+      const entry = (await observe()).pendingStart.find((p) =>
+        p.workIds?.includes(workId),
+      );
       assert(entry);
-      expect(entry.segment).toBe(toTimestamp(Math.ceil(runAt)));
+      expect(entry.segment).toBe(toTimestamp(runAt));
 
       vi.advanceTimersByTime(1);
       await runLoop();
-      expect((await observe()).running.map((r) => r.workId)).toContain(workId);
+      expect((await observe()).running.map((r) => r.workId)).toEqual([workId]);
     });
   });
 

--- a/src/component/loop.ts
+++ b/src/component/loop.ts
@@ -105,7 +105,7 @@ type Start = Infer<typeof vStart>;
 
 // batch-worker runs `getBatch` and `run` in the same transaction, so a batch
 // never crosses a deploy or a snapshot: `run` sees exactly the state the
-// batch was built from.
+// batch was built from, and `snapshotTs()` answers the same in both.
 /** The shape `getBatch` hands to `run`. */
 const batchFields = {
   // What "now" was (in nanoseconds) when the batch was built.
@@ -121,11 +121,6 @@ const batchFields = {
   // is absent when it inspected nothing.
   sweepStarts: v.array(vStart),
   sweepStop: v.optional(v.int64()),
-  // The snapshot the batch was read at. It is the eligibility bound — a ready
-  // entry's commit stamp is at or below it, and a scheduled entry is due once
-  // the commit clock passes its start time — and the floor for the keys this
-  // run writes, since nothing committing later is stamped at or below it.
-  snapshot: v.int64(),
 };
 type Batch = Infer<ReturnType<typeof v.object<typeof batchFields>>>;
 
@@ -148,7 +143,6 @@ export const getBatch = internalQuery({
     const cursors = state?.segmentCursors ?? INITIAL_STATE.segmentCursors;
     const lastRecovery = state?.lastRecovery ?? INITIAL_STATE.lastRecovery;
     const nowTs = toTimestamp(Date.now());
-    const snapshot = snapshotTs();
 
     // Once per recovery period (≈1min), check for stuck running jobs. The
     // pending queues need no periodic rescan: they're ordered by commit
@@ -164,7 +158,6 @@ export const getBatch = internalQuery({
         sweepCursor: cursors.sweep ?? 0n,
         maxParallelism: globals.maxParallelism,
         runningCount: running.length,
-        snapshot,
       });
 
     // The sweep counts as work when it found entries to start or moved past
@@ -197,7 +190,6 @@ export const getBatch = internalQuery({
         starts,
         sweepStarts,
         sweepStop,
-        snapshot,
       };
       return { kind: "work" as const, batch };
     }
@@ -212,7 +204,7 @@ export const getBatch = internalQuery({
     // includes this one's commit) picks it up.
     const futureStart = await ctx.db
       .query("pendingStart")
-      .withIndex("segment", (q) => q.gt("segment", snapshot))
+      .withIndex("segment", (q) => q.gt("segment", snapshotTs()))
       .first();
     const waits: number[] = [];
     if (futureStart) {
@@ -259,7 +251,6 @@ export const run = internalMutation({
       state,
       batch.completions,
       console,
-      batch.snapshot,
     );
     console.timeEnd(compLabel);
 
@@ -303,7 +294,7 @@ export const run = internalMutation({
     if (notYet.length > 0) {
       const promoteLabel = `[main] promote(${notYet.length})`;
       console.time(promoteLabel);
-      await promoteScheduled(ctx, notYet, batch.snapshot);
+      await promoteScheduled(ctx, notYet);
       console.timeEnd(promoteLabel);
     }
 
@@ -399,7 +390,6 @@ async function queryPending(
     sweepCursor,
     maxParallelism,
     runningCount,
-    snapshot,
   }: {
     completionCursor: bigint;
     cancelationCursor: bigint;
@@ -407,7 +397,6 @@ async function queryPending(
     sweepCursor: bigint;
     maxParallelism: number;
     runningCount: number;
-    snapshot: bigint;
   },
 ) {
   const completions = await ctx.db
@@ -512,19 +501,24 @@ async function queryPending(
   }
 
   // Entries the sweep starts take slots first; only fetch ready work for the
-  // slots left over. Everything eligible, oldest first: ready entries are
-  // stamped at or below the snapshot by definition, and scheduled work sorts
-  // above it until the commit clock reaches its start time, so it's left alone
-  // without pinning the cursor. Documents are read whole, but a partially-taken
-  // document is safe: the cursor stops at its `segment`, and the inclusive
-  // re-read picks up the entries left behind.
+  // slots left over. Everything eligible, oldest first. Documents are read
+  // whole, but a partially-taken document is safe: the cursor stops at its
+  // `segment`, and the inclusive re-read picks up the entries left behind.
+  //
+  // The snapshot this transaction reads at is the eligibility bound. A ready
+  // entry's key is its commit stamp, which is at or below the snapshot by
+  // definition, so it's eligible as soon as it's visible. A scheduled entry's
+  // key is its start time, so it sorts above the snapshot until the commit
+  // clock reaches that time and is left alone without pinning the cursor. And
+  // because nothing committing later is stamped at or below the snapshot, the
+  // cursor can rest on any key read here without passing something unseen.
   const readyLimit = Math.max(0, startLimit - sweepStarts.length);
   const starts: Start[] = [];
   if (readyLimit > 0) {
     const stream = ctx.db
       .query("pendingStart")
       .withIndex("segment", (q) =>
-        q.gte("segment", incomingCursor).lte("segment", snapshot),
+        q.gte("segment", incomingCursor).lte("segment", snapshotTs()),
       );
     scan: for await (const doc of stream) {
       const segment = doc.segment as bigint;
@@ -579,7 +573,6 @@ async function handleCompletions(
   state: Doc<"internalState">,
   completed: Completion[],
   console: Logger,
-  snapshot: bigint,
 ) {
   // Completions that were going to be retried but have since been canceled.
   const toCancel: CompleteJob[] = [];
@@ -601,7 +594,7 @@ async function handleCompletions(
           console.warn(`[main] ${c.workId} is gone, but trying to complete`);
           return;
         }
-        if (await rescheduleJob(ctx, work, console, snapshot)) {
+        if (await rescheduleJob(ctx, work, console)) {
           state.report.retries++;
           recordCompleted(console, work, "retrying", undefined);
         } else {
@@ -748,11 +741,8 @@ async function handleRecovery(
  * the snapshot this run, and a wall-clock start time just ahead of `Date.now()`
  * may already be behind the commit clock.
  */
-async function promoteScheduled(
-  ctx: MutationCtx,
-  notYet: Start[],
-  snapshot: bigint,
-) {
+async function promoteScheduled(ctx: MutationCtx, notYet: Start[]) {
+  const snapshot = snapshotTs();
   await Promise.all(
     notYet.map(async ({ _id, legacyStartTime }) => {
       assert(legacyStartTime);
@@ -949,7 +939,6 @@ async function rescheduleJob(
   ctx: MutationCtx,
   work: Doc<"work">,
   console: Logger,
-  snapshot: bigint,
 ): Promise<boolean> {
   const pendingCancelation = await ctx.db
     .query("pendingCancelation")
@@ -984,7 +973,10 @@ async function rescheduleJob(
   // Raised to at least the snapshot, the furthest the cursor this transaction
   // writes can reach, so the entry can't land behind it. A backoff shorter than
   // the skew between the wall and commit clocks starts next iteration.
-  const segment = maxBigint(toTimestamp(Date.now() + nextAttempt), snapshot);
+  const segment = maxBigint(
+    toTimestamp(Date.now() + nextAttempt),
+    snapshotTs(),
+  );
   const pendingStartId = await ctx.db.insert("pendingStart", {
     workIds: [work._id],
     segment,

--- a/src/component/loop.ts
+++ b/src/component/loop.ts
@@ -20,7 +20,6 @@ import {
 import {
   type Config,
   DEFAULT_MAX_PARALLELISM,
-  endOfMs,
   fromTimestamp,
   legacyRunAt,
   MINUTE,
@@ -121,10 +120,11 @@ const batchFields = {
   // is absent when it inspected nothing.
   sweepStarts: v.array(vStart),
   sweepStop: v.optional(v.int64()),
-  // The snapshot the batch was read at. Nothing that commits later is stamped
-  // at or below it, so it is the frontier the incoming cursor may advance to,
-  // but not beyond.
-  cursorCeiling: v.int64(),
+  // The snapshot the batch was read at. It is the eligibility bound — a ready
+  // entry's commit stamp is at or below it, and a scheduled entry is due once
+  // the commit clock passes its start time — and the floor for the keys this
+  // run writes, since nothing committing later is stamped at or below it.
+  snapshot: v.int64(),
 };
 type Batch = Infer<ReturnType<typeof v.object<typeof batchFields>>>;
 
@@ -147,7 +147,7 @@ export const getBatch = internalQuery({
     const cursors = state?.segmentCursors ?? INITIAL_STATE.segmentCursors;
     const lastRecovery = state?.lastRecovery ?? INITIAL_STATE.lastRecovery;
     const nowTs = toTimestamp(Date.now());
-    const eligibleBefore = endOfMs(Date.now());
+    const snapshot = snapshotTs();
 
     // Once per recovery period (≈1min), check for stuck running jobs. The
     // pending queues need no periodic rescan: they're ordered by commit
@@ -163,7 +163,7 @@ export const getBatch = internalQuery({
         sweepCursor: cursors.sweep ?? 0n,
         maxParallelism: globals.maxParallelism,
         runningCount: running.length,
-        eligibleBefore,
+        snapshot,
       });
 
     // The sweep counts as work when it found entries to start or moved past
@@ -196,7 +196,7 @@ export const getBatch = internalQuery({
         starts,
         sweepStarts,
         sweepStop,
-        cursorCeiling: snapshotTs(),
+        snapshot,
       };
       return { kind: "work" as const, batch };
     }
@@ -206,9 +206,12 @@ export const getBatch = internalQuery({
     // recovery scan. A ping still wakes us sooner. Work the sweep couldn't
     // retire (a due entry with no capacity) is covered too: capacity implies
     // jobs are running, so the recovery wait applies and completions ping us.
+    // The wait is measured on the wall clock; if the commit clock lags it, the
+    // entry isn't due yet on waking and the next iteration (whose snapshot
+    // includes this one's commit) picks it up.
     const futureStart = await ctx.db
       .query("pendingStart")
-      .withIndex("segment", (q) => q.gte("segment", eligibleBefore))
+      .withIndex("segment", (q) => q.gt("segment", snapshot))
       .first();
     const waits: number[] = [];
     if (futureStart) {
@@ -255,6 +258,7 @@ export const run = internalMutation({
       state,
       batch.completions,
       console,
+      batch.snapshot,
     );
     console.timeEnd(compLabel);
 
@@ -277,10 +281,10 @@ export const run = internalMutation({
 
     // ── Start new work ──
     // The segment scan's entries are all due (scheduled ones only become
-    // visible at their start time), except entries written by older versions,
-    // which the loop re-keys to their start time. The sweep's entries are the
-    // opposite — committed *behind* the cursor, so the scan will never reach
-    // them; they start from here.
+    // eligible once the snapshot passes their start time), except entries
+    // written by older versions, which the loop re-keys to their start time.
+    // The sweep's entries are the opposite — committed *behind* the cursor, so
+    // the scan will never reach them; they start from here.
     const now = Date.now();
     const isDue = (s: Start) =>
       s.legacyStartTime === undefined || s.legacyStartTime <= now;
@@ -298,7 +302,7 @@ export const run = internalMutation({
     if (notYet.length > 0) {
       const promoteLabel = `[main] promote(${notYet.length})`;
       console.time(promoteLabel);
-      await promoteScheduled(ctx, notYet);
+      await promoteScheduled(ctx, notYet, batch.snapshot);
       console.timeEnd(promoteLabel);
     }
 
@@ -344,24 +348,18 @@ export const run = internalMutation({
     }
     // Capacity can cut the starts short, so only advance each cursor over the
     // leading run we finished with — started or re-keyed. Stopping at the
-    // first entry we left alone is what keeps it from being skipped. The
-    // incoming cursor additionally never passes `cursorCeiling`, the snapshot
-    // the batch was read at: a wall-clock key can exceed every commit stamp
-    // that exists, and a commit racing this run would land behind a cursor
-    // set there. (The keys this run itself writes need no accounting — they're
-    // all at or above the end of the current millisecond, which no cursor
-    // reaches: the scan's bound is exclusive and the ceiling only lowers.)
-    // Equality is fine throughout: the index is read with `gte`. Nor can the
-    // ceiling move the cursor backwards: the previous run set it at or below
-    // its own snapshot, and this run's snapshot includes that run's commit.
+    // first entry we left alone is what keeps it from being skipped. Every key
+    // the scan read is at or below the snapshot, and nothing committing after
+    // the snapshot is stamped at or below it, so the cursor can rest on the
+    // last handled key. The keys this run itself writes are raised to at least
+    // the snapshot (see `rescheduleJob` and `promoteScheduled`), so they can't
+    // land behind it either. Equality is fine throughout: the index is read
+    // with `gte`.
     const handled = new Set([...pending, ...notYet].map((s) => s._id));
-    let incoming = state.segmentCursors.incoming;
     for (const start of batch.starts) {
       if (!handled.has(start._id)) break;
-      incoming = start.segment;
+      state.segmentCursors.incoming = start.segment;
     }
-    state.segmentCursors.incoming =
-      incoming < batch.cursorCeiling ? incoming : batch.cursorCeiling;
     // The sweep cursor rests at the last inspected entry — (commit stamp,
     // creation time), since a batch enqueue shares one stamp. Its components
     // are read straight off inspected entries, so no ceiling is needed. If
@@ -400,7 +398,7 @@ async function queryPending(
     sweepCursor,
     maxParallelism,
     runningCount,
-    eligibleBefore,
+    snapshot,
   }: {
     completionCursor: bigint;
     cancelationCursor: bigint;
@@ -408,7 +406,7 @@ async function queryPending(
     sweepCursor: bigint;
     maxParallelism: number;
     runningCount: number;
-    eligibleBefore: bigint;
+    snapshot: bigint;
   },
 ) {
   const completions = await ctx.db
@@ -466,7 +464,8 @@ async function queryPending(
     const take = (doc: Doc<"pendingStart">): "more" | "stop" => {
       const segment = doc.segment as bigint;
       const ids = memberIds(doc).filter((id) => !excluded.has(id));
-      // Behind the cursor, so due: the cursor never passes the current time.
+      // Behind the cursor, so due: the cursor never passes the snapshot, which
+      // is the eligibility bound.
       // Take what fits in the start slots. A partially-taken document keeps
       // the cursor at bay — its started entries patch out and the next pass
       // re-finds the rest.
@@ -512,19 +511,19 @@ async function queryPending(
   }
 
   // Entries the sweep starts take slots first; only fetch ready work for the
-  // slots left over. Everything eligible, oldest first; work scheduled for
-  // later sorts above the bound, so it's left alone without pinning the
-  // cursor. Documents are read whole, but a partially-taken document is safe:
-  // the cursor stops at its `segment`, and the inclusive re-read picks up the
-  // entries left behind.
-  //
+  // slots left over. Everything eligible, oldest first: ready entries are
+  // stamped at or below the snapshot by definition, and scheduled work sorts
+  // above it until the commit clock reaches its start time, so it's left alone
+  // without pinning the cursor. Documents are read whole, but a partially-taken
+  // document is safe: the cursor stops at its `segment`, and the inclusive
+  // re-read picks up the entries left behind.
   const readyLimit = Math.max(0, startLimit - sweepStarts.length);
   const starts: Start[] = [];
   if (readyLimit > 0) {
     const stream = ctx.db
       .query("pendingStart")
       .withIndex("segment", (q) =>
-        q.gte("segment", incomingCursor).lt("segment", eligibleBefore),
+        q.gte("segment", incomingCursor).lte("segment", snapshot),
       );
     scan: for await (const doc of stream) {
       const segment = doc.segment as bigint;
@@ -579,6 +578,7 @@ async function handleCompletions(
   state: Doc<"internalState">,
   completed: Completion[],
   console: Logger,
+  snapshot: bigint,
 ) {
   // Completions that were going to be retried but have since been canceled.
   const toCancel: CompleteJob[] = [];
@@ -600,7 +600,7 @@ async function handleCompletions(
           console.warn(`[main] ${c.workId} is gone, but trying to complete`);
           return;
         }
-        if (await rescheduleJob(ctx, work, console)) {
+        if (await rescheduleJob(ctx, work, console, snapshot)) {
           state.report.retries++;
           recordCompleted(console, work, "retrying", undefined);
         } else {
@@ -746,18 +746,23 @@ function maxBigint(a: bigint, b: bigint) {
  * Re-keys entries that are visible but not due to sort at their start time,
  * so the cursor can pass them and they don't come back until they're actually
  * due. New-format entries are keyed at their start time and only become
- * visible once due, so this only handles the 100ms buckets older versions
- * wrote. The new key needs no clamping: a not-yet-due start time is in the
- * future, which the cursor won't exceed in this transaction.
+ * eligible once due, so this only handles the 100ms buckets older versions
+ * wrote. The new key is raised to at least the snapshot: the cursor can reach
+ * the snapshot this run, and a wall-clock start time just ahead of `Date.now()`
+ * may already be behind the commit clock.
  */
-async function promoteScheduled(ctx: MutationCtx, notYet: Start[]) {
+async function promoteScheduled(
+  ctx: MutationCtx,
+  notYet: Start[],
+  snapshot: bigint,
+) {
   await Promise.all(
     notYet.map(async ({ _id, legacyStartTime }) => {
       assert(legacyStartTime);
       // A concurrent cancelation may have removed it.
       if (!(await ctx.db.get("pendingStart", _id))) return;
       await ctx.db.patch("pendingStart", _id, {
-        segment: toTimestamp(legacyStartTime),
+        segment: maxBigint(toTimestamp(legacyStartTime), snapshot),
         // No `scanTs`: written by the loop, it can't be out of order.
       });
     }),
@@ -947,6 +952,7 @@ async function rescheduleJob(
   ctx: MutationCtx,
   work: Doc<"work">,
   console: Logger,
+  snapshot: bigint,
 ): Promise<boolean> {
   const pendingCancelation = await ctx.db
     .query("pendingCancelation")
@@ -978,9 +984,10 @@ async function rescheduleJob(
     work.retryBehavior.initialBackoffMs *
     Math.pow(work.retryBehavior.base, work.attempts - 1);
   const nextAttempt = withJitter(backoffMs);
-  // Unlike enqueue, this can't land behind the cursor since it's in the future
-  // and written in the same transaction as we update cursor to at most "now"
-  const segment = toTimestamp(Date.now() + Math.max(nextAttempt, 1));
+  // Raised to at least the snapshot, the furthest the cursor this transaction
+  // writes can reach, so the entry can't land behind it. A backoff shorter than
+  // the skew between the wall and commit clocks starts next iteration.
+  const segment = maxBigint(toTimestamp(Date.now() + nextAttempt), snapshot);
   const pendingStartId = await ctx.db.insert("pendingStart", {
     workIds: [work._id],
     segment,

--- a/src/component/loop.ts
+++ b/src/component/loop.ts
@@ -26,6 +26,7 @@ import {
   MINUTE,
   SECOND,
   type RunResult,
+  snapshotTs,
   toTimestamp,
   vResult,
 } from "./shared.js";
@@ -120,8 +121,9 @@ const batchFields = {
   // is absent when it inspected nothing.
   sweepStarts: v.array(vStart),
   sweepStop: v.optional(v.int64()),
-  // The highest commit timestamp observed while building the batch — the
-  // frontier the incoming cursor may advance to, but not beyond.
+  // The snapshot the batch was read at. Nothing that commits later is stamped
+  // at or below it, so it is the frontier the incoming cursor may advance to,
+  // but not beyond.
   cursorCeiling: v.int64(),
 };
 type Batch = Infer<ReturnType<typeof v.object<typeof batchFields>>>;
@@ -153,23 +155,16 @@ export const getBatch = internalQuery({
     const isRecoveryIter =
       running.length > 0 && nowTs - lastRecovery >= RECOVERY_PERIOD_NS;
 
-    const {
-      starts,
-      sweepStarts,
-      sweepStop,
-      cancelations,
-      completions,
-      cursorCeiling,
-    } = await queryPending(ctx, {
-      completionCursor: cursors.completion,
-      cancelationCursor: cursors.cancelation,
-      incomingCursor: cursors.incoming,
-      sweepCursor: cursors.sweep ?? 0n,
-      lastCommitTs: (state?.lastCommitTs as bigint | undefined) ?? 0n,
-      maxParallelism: globals.maxParallelism,
-      runningCount: running.length,
-      eligibleBefore,
-    });
+    const { starts, sweepStarts, sweepStop, cancelations, completions } =
+      await queryPending(ctx, {
+        completionCursor: cursors.completion,
+        cancelationCursor: cursors.cancelation,
+        incomingCursor: cursors.incoming,
+        sweepCursor: cursors.sweep ?? 0n,
+        maxParallelism: globals.maxParallelism,
+        runningCount: running.length,
+        eligibleBefore,
+      });
 
     // The sweep counts as work when it found entries to start or moved past
     // new documents; re-verifying the live documents at its inclusive
@@ -201,7 +196,7 @@ export const getBatch = internalQuery({
         starts,
         sweepStarts,
         sweepStop,
-        cursorCeiling,
+        cursorCeiling: snapshotTs(),
       };
       return { kind: "work" as const, batch };
     }
@@ -350,26 +345,23 @@ export const run = internalMutation({
     // Capacity can cut the starts short, so only advance each cursor over the
     // leading run we finished with — started or re-keyed. Stopping at the
     // first entry we left alone is what keeps it from being skipped. The
-    // incoming cursor additionally never passes `cursorCeiling`, the highest
-    // commit timestamp observed while building the batch: a wall-clock key
-    // can exceed every commit stamp that exists, and a commit racing this run
-    // would land behind a cursor set there. (The keys this run itself writes
-    // need no accounting — they're all at or above the end of the current
-    // millisecond, which no cursor reaches: the scan's bound is exclusive and
-    // the ceiling only lowers.) Equality is fine throughout: the index is
-    // read with `gte`.
+    // incoming cursor additionally never passes `cursorCeiling`, the snapshot
+    // the batch was read at: a wall-clock key can exceed every commit stamp
+    // that exists, and a commit racing this run would land behind a cursor
+    // set there. (The keys this run itself writes need no accounting — they're
+    // all at or above the end of the current millisecond, which no cursor
+    // reaches: the scan's bound is exclusive and the ceiling only lowers.)
+    // Equality is fine throughout: the index is read with `gte`. Nor can the
+    // ceiling move the cursor backwards: the previous run set it at or below
+    // its own snapshot, and this run's snapshot includes that run's commit.
     const handled = new Set([...pending, ...notYet].map((s) => s._id));
     let incoming = state.segmentCursors.incoming;
     for (const start of batch.starts) {
       if (!handled.has(start._id)) break;
       incoming = start.segment;
     }
-    // Never backwards: a batch can carry a ceiling below the cursor when it
-    // observed no commit stamps at all (e.g. a recovery-only iteration).
-    state.segmentCursors.incoming = maxBigint(
-      state.segmentCursors.incoming,
-      incoming < batch.cursorCeiling ? incoming : batch.cursorCeiling,
-    );
+    state.segmentCursors.incoming =
+      incoming < batch.cursorCeiling ? incoming : batch.cursorCeiling;
     // The sweep cursor rests at the last inspected entry — (commit stamp,
     // creation time), since a batch enqueue shares one stamp. Its components
     // are read straight off inspected entries, so no ceiling is needed. If
@@ -385,10 +377,6 @@ export const run = internalMutation({
         batch.sweepStop,
       );
     }
-    // Record this run's own commit stamp: the next run reads this document,
-    // so its snapshot is at least this recent, and the mark seeds its ceiling.
-    state.lastCommitTs = ctx.db.vars.commitTs;
-
     await ctx.db.replace("internalState", state._id, state);
     // Return null: batch-worker re-runs `getBatch` immediately to drain, and
     // idles (per getBatch's hints) once there's nothing left.
@@ -410,7 +398,6 @@ async function queryPending(
     cancelationCursor,
     incomingCursor,
     sweepCursor,
-    lastCommitTs,
     maxParallelism,
     runningCount,
     eligibleBefore,
@@ -419,7 +406,6 @@ async function queryPending(
     cancelationCursor: bigint;
     incomingCursor: bigint;
     sweepCursor: bigint;
-    lastCommitTs: bigint;
     maxParallelism: number;
     runningCount: number;
     eligibleBefore: bigint;
@@ -534,7 +520,6 @@ async function queryPending(
   //
   const readyLimit = Math.max(0, startLimit - sweepStarts.length);
   const starts: Start[] = [];
-  const readyStamps: bigint[] = [];
   if (readyLimit > 0) {
     const stream = ctx.db
       .query("pendingStart")
@@ -547,9 +532,6 @@ async function queryPending(
       // in `segment`; recovering it here means `run` handles it like any
       // other not-yet-due entry and re-keys it as a timestamp.
       const legacyStartTime = legacyRunAt(segment);
-      if (doc.scheduled !== true && legacyStartTime === undefined) {
-        readyStamps.push(segment);
-      }
       for (const workId of memberIds(doc)) {
         if (excluded.has(workId)) continue;
         if (starts.length >= readyLimit) break scan;
@@ -557,29 +539,7 @@ async function queryPending(
       }
     }
   }
-  // The highest commit timestamp observed while building this batch. Every
-  // source is the stamp of a transaction visible to this snapshot, so
-  // anything committing later is stamped above it — the frontier the cursor
-  // may advance to. `scheduled` documents are wall-clock-keyed and don't
-  // count (their stamps do, via the sweep); the rest carry an observed commit
-  // stamp in `segment` (an older version's tiny buckets are excluded with the
-  // same check that recovers their start time).
-  const cursorCeiling = [
-    lastCommitTs,
-    ...completions.map((c) => c.segment as bigint),
-    ...cancelations.map((c) => c.segment as bigint),
-    ...readyStamps,
-    ...(sweepStop === undefined ? [] : [sweepStop]),
-  ].reduce(maxBigint);
-
-  return {
-    completions,
-    cancelations,
-    starts,
-    sweepStarts,
-    sweepStop,
-    cursorCeiling,
-  };
+  return { completions, cancelations, starts, sweepStarts, sweepStop };
 }
 
 /** The work queued in a pendingStart document. */
@@ -798,10 +758,7 @@ async function promoteScheduled(ctx: MutationCtx, notYet: Start[]) {
       if (!(await ctx.db.get("pendingStart", _id))) return;
       await ctx.db.patch("pendingStart", _id, {
         segment: toTimestamp(legacyStartTime),
-        // The key is now a wall-clock time, and `scheduled` is what records
-        // that (so the cursor ceiling doesn't count it as a commit stamp).
         // No `scanTs`: written by the loop, it can't be out of order.
-        scheduled: true,
       });
     }),
   );
@@ -1027,7 +984,6 @@ async function rescheduleJob(
   const pendingStartId = await ctx.db.insert("pendingStart", {
     workIds: [work._id],
     segment,
-    scheduled: true,
   });
   await ctx.db.patch("work", work._id, { pendingStartId });
   return true;

--- a/src/component/loop.ts
+++ b/src/component/loop.ts
@@ -20,6 +20,7 @@ import {
 import {
   type Config,
   DEFAULT_MAX_PARALLELISM,
+  eligibilityBound,
   fromTimestamp,
   legacyRunAt,
   maxBigint,
@@ -199,11 +200,9 @@ export const getBatch = internalQuery({
     // recovery scan. A ping still wakes us sooner. Work the sweep couldn't
     // retire (a due entry with no capacity) is covered too: capacity implies
     // jobs are running, so the recovery wait applies and completions ping us.
-    // The wait is on the wall clock while eligibility is on the commit clock,
-    // so waking early just costs an iteration.
     const futureStart = await ctx.db
       .query("pendingStart")
-      .withIndex("segment", (q) => q.gt("segment", snapshotTs()))
+      .withIndex("segment", (q) => q.gt("segment", eligibilityBound()))
       .first();
     const waits: number[] = [];
     if (futureStart) {
@@ -339,14 +338,17 @@ export const run = internalMutation({
     }
     // Capacity can cut the starts short, so only advance each cursor over the
     // leading run we finished with — started or re-keyed. Stopping at the
-    // first entry we left alone is what keeps it from being skipped. Any key
-    // the scan read is a safe resting point: nothing can commit at or below
-    // the snapshot it was read under. Equality is fine throughout: the index is
+    // first entry we left alone is what keeps it from being skipped. The
+    // cursor also never passes the snapshot: a wall-clock key can sit above
+    // every commit stamp that exists, and a commit racing this run would land
+    // behind a cursor set there. Equality is fine throughout: the index is
     // read with `gte`.
     const handled = new Set([...pending, ...notYet].map((s) => s._id));
+    const snapshot = snapshotTs();
     for (const start of batch.starts) {
       if (!handled.has(start._id)) break;
-      state.segmentCursors.incoming = start.segment;
+      state.segmentCursors.incoming =
+        start.segment < snapshot ? start.segment : snapshot;
     }
     // The sweep cursor rests at the last inspected entry — (commit stamp,
     // creation time), since a batch enqueue shares one stamp. Its components
@@ -499,19 +501,13 @@ async function queryPending(
   // slots left over. Everything eligible, oldest first. Documents are read
   // whole, but a partially-taken document is safe: the cursor stops at its
   // `segment`, and the inclusive re-read picks up the entries left behind.
-  //
-  // The bound is the snapshot rather than the wall clock: a ready entry's
-  // commit stamp is at or below it by definition, a scheduled entry's start
-  // time sorts above it until the commit clock gets there, and no later commit
-  // can land at or below it — so one value is both the eligibility test and a
-  // safe resting point for the cursor.
   const readyLimit = Math.max(0, startLimit - sweepStarts.length);
   const starts: Start[] = [];
   if (readyLimit > 0) {
     const stream = ctx.db
       .query("pendingStart")
       .withIndex("segment", (q) =>
-        q.gte("segment", incomingCursor).lte("segment", snapshotTs()),
+        q.gte("segment", incomingCursor).lte("segment", eligibilityBound()),
       );
     scan: for await (const doc of stream) {
       const segment = doc.segment as bigint;

--- a/src/component/loop.ts
+++ b/src/component/loop.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_MAX_PARALLELISM,
   fromTimestamp,
   legacyRunAt,
+  maxBigint,
   MINUTE,
   SECOND,
   type RunResult,
@@ -736,10 +737,6 @@ async function handleRecovery(
     const batch = jobs.slice(i, i + RECOVERY_BATCH_SIZE);
     await ctx.scheduler.runAfter(0, internal.recovery.recover, { jobs: batch });
   }
-}
-
-function maxBigint(a: bigint, b: bigint) {
-  return a > b ? a : b;
 }
 
 /**

--- a/src/component/loop.ts
+++ b/src/component/loop.ts
@@ -105,7 +105,7 @@ type Start = Infer<typeof vStart>;
 
 // batch-worker runs `getBatch` and `run` in the same transaction, so a batch
 // never crosses a deploy or a snapshot: `run` sees exactly the state the
-// batch was built from, and `snapshotTs()` answers the same in both.
+// batch was built from.
 /** The shape `getBatch` hands to `run`. */
 const batchFields = {
   // What "now" was (in nanoseconds) when the batch was built.
@@ -199,9 +199,8 @@ export const getBatch = internalQuery({
     // recovery scan. A ping still wakes us sooner. Work the sweep couldn't
     // retire (a due entry with no capacity) is covered too: capacity implies
     // jobs are running, so the recovery wait applies and completions ping us.
-    // The wait is measured on the wall clock; if the commit clock lags it, the
-    // entry isn't due yet on waking and the next iteration (whose snapshot
-    // includes this one's commit) picks it up.
+    // The wait is on the wall clock while eligibility is on the commit clock,
+    // so waking early just costs an iteration.
     const futureStart = await ctx.db
       .query("pendingStart")
       .withIndex("segment", (q) => q.gt("segment", snapshotTs()))
@@ -340,13 +339,10 @@ export const run = internalMutation({
     }
     // Capacity can cut the starts short, so only advance each cursor over the
     // leading run we finished with — started or re-keyed. Stopping at the
-    // first entry we left alone is what keeps it from being skipped. Every key
-    // the scan read is at or below the snapshot, and nothing committing after
-    // the snapshot is stamped at or below it, so the cursor can rest on the
-    // last handled key. The keys this run itself writes are raised to at least
-    // the snapshot (see `rescheduleJob` and `promoteScheduled`), so they can't
-    // land behind it either. Equality is fine throughout: the index is read
-    // with `gte`.
+    // first entry we left alone is what keeps it from being skipped. Any key
+    // the scan read is a safe resting point: nothing can commit at or below
+    // the snapshot it was read under. Equality is fine throughout: the index is
+    // read with `gte`.
     const handled = new Set([...pending, ...notYet].map((s) => s._id));
     for (const start of batch.starts) {
       if (!handled.has(start._id)) break;
@@ -454,8 +450,7 @@ async function queryPending(
     const take = (doc: Doc<"pendingStart">): "more" | "stop" => {
       const segment = doc.segment as bigint;
       const ids = memberIds(doc).filter((id) => !excluded.has(id));
-      // Behind the cursor, so due: the cursor never passes the snapshot, which
-      // is the eligibility bound.
+      // Behind the cursor, so due: the cursor never passes the eligibility bound.
       // Take what fits in the start slots. A partially-taken document keeps
       // the cursor at bay — its started entries patch out and the next pass
       // re-finds the rest.
@@ -505,13 +500,11 @@ async function queryPending(
   // whole, but a partially-taken document is safe: the cursor stops at its
   // `segment`, and the inclusive re-read picks up the entries left behind.
   //
-  // The snapshot this transaction reads at is the eligibility bound. A ready
-  // entry's key is its commit stamp, which is at or below the snapshot by
-  // definition, so it's eligible as soon as it's visible. A scheduled entry's
-  // key is its start time, so it sorts above the snapshot until the commit
-  // clock reaches that time and is left alone without pinning the cursor. And
-  // because nothing committing later is stamped at or below the snapshot, the
-  // cursor can rest on any key read here without passing something unseen.
+  // The bound is the snapshot rather than the wall clock: a ready entry's
+  // commit stamp is at or below it by definition, a scheduled entry's start
+  // time sorts above it until the commit clock gets there, and no later commit
+  // can land at or below it — so one value is both the eligibility test and a
+  // safe resting point for the cursor.
   const readyLimit = Math.max(0, startLimit - sweepStarts.length);
   const starts: Start[] = [];
   if (readyLimit > 0) {
@@ -737,9 +730,8 @@ async function handleRecovery(
  * so the cursor can pass them and they don't come back until they're actually
  * due. New-format entries are keyed at their start time and only become
  * eligible once due, so this only handles the 100ms buckets older versions
- * wrote. The new key is raised to at least the snapshot: the cursor can reach
- * the snapshot this run, and a wall-clock start time just ahead of `Date.now()`
- * may already be behind the commit clock.
+ * wrote. The new key is raised to at least the snapshot, which the cursor may
+ * reach this run, so it can't land behind it.
  */
 async function promoteScheduled(ctx: MutationCtx, notYet: Start[]) {
   const snapshot = snapshotTs();
@@ -970,9 +962,9 @@ async function rescheduleJob(
     work.retryBehavior.initialBackoffMs *
     Math.pow(work.retryBehavior.base, work.attempts - 1);
   const nextAttempt = withJitter(backoffMs);
-  // Raised to at least the snapshot, the furthest the cursor this transaction
-  // writes can reach, so the entry can't land behind it. A backoff shorter than
-  // the skew between the wall and commit clocks starts next iteration.
+  // Raised to at least the snapshot, which the cursor may reach this run, so
+  // the retry can't land behind it; a backoff shorter than the clocks' skew
+  // just starts next iteration.
   const segment = maxBigint(
     toTimestamp(Date.now() + nextAttempt),
     snapshotTs(),

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -33,10 +33,6 @@ export default defineSchema({
       // beginning".
       sweep: v.optional(timestamp),
     }),
-    // The commit timestamp of the previous `run`. Every transaction stamped
-    // at or below it is visible to any reader of this document, so it is a
-    // safe lower bound on the next run's snapshot.
-    lastCommitTs: v.optional(v.commitTs()),
     // When the loop last checked for stuck jobs, in nanoseconds.
     // In ≤ 0.4.9, values were 100ms buckets, interpreted as long ago.
     lastRecovery: timestamp,
@@ -88,9 +84,6 @@ export default defineSchema({
     // @deprecated The single entry of a document written by version ≤ 0.4.9.
     workId: v.optional(v.id("work")),
     segment,
-    // Present iff `segment` is a wall-clock start time rather than a commit
-    // timestamp.
-    scheduled: v.optional(v.boolean()),
     // The enqueue's commit timestamp, present iff the document could have
     // committed out of order (a scheduled start within five minutes).
     scanTs: v.optional(v.commitTs()),

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -65,14 +65,6 @@ export function fromTimestamp(timestamp: bigint): number {
   );
 }
 
-/**
- * The exclusive upper bound on entries eligible at `ms` — the end of that
- * millisecond, not the start of it.
- */
-export function endOfMs(ms: number): bigint {
-  return toTimestamp(Math.floor(ms) + 1);
-}
-
 declare const Convex: {
   syscall: (op: string, jsonArgs: string) => string;
 };

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -86,6 +86,16 @@ export function maxBigint(a: bigint, b: bigint): bigint {
   return a > b ? a : b;
 }
 
+/**
+ * The highest key eligible to start: the later of the snapshot and the wall
+ * clock. Ready entries carry a commit stamp, at or below the snapshot; scheduled
+ * entries carry a start time, due when either clock reaches it. Taking the
+ * later of the two means neither clock lagging the other holds work back.
+ */
+export function eligibilityBound(): bigint {
+  return maxBigint(snapshotTs(), toTimestamp(Date.now()));
+}
+
 // Nanoseconds for the year 2000: far above any 100ms bucket an older version
 // could have written (~1.8e10 today, ~1.9e10 even four years out) and far below
 // any timestamp this one can produce, since `boundScheduledTime` keeps

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -85,6 +85,10 @@ export function snapshotTs(): bigint {
   return jsonToConvex(JSON.parse(json)) as bigint;
 }
 
+export function maxBigint(a: bigint, b: bigint): bigint {
+  return a > b ? a : b;
+}
+
 // Nanoseconds for the year 2000: far above any 100ms bucket an older version
 // could have written (~1.8e10 today, ~1.9e10 even four years out) and far below
 // any timestamp this one can produce, since `boundScheduledTime` keeps

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -70,12 +70,9 @@ declare const Convex: {
 };
 
 /**
- * The timestamp of the snapshot this transaction reads from, in nanoseconds on
- * the commit-timestamp clock. Every transaction stamped at or below it is
- * visible to this one, and every transaction that commits after it — whether
- * or not it has started yet — is stamped above it. So it is the highest value
- * a cursor over a commit-ordered index can advance to without passing
- * something it hasn't read.
+ * The snapshot this transaction reads at, in nanoseconds on the
+ * commit-timestamp clock. Everything stamped at or below it is visible here,
+ * and everything that commits later is stamped above it.
  *
  * TODO(convex): replace with `ctx.meta.getSnapshotTs()` once a released
  * `convex` exposes it; this is the syscall it wraps.

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -1,6 +1,6 @@
 import type { Infer, Validator, VAny } from "convex/values";
 
-import { v } from "convex/values";
+import { jsonToConvex, v } from "convex/values";
 import { type Logger, logLevel } from "./logging.js";
 
 export const fnType = v.union(
@@ -71,6 +71,26 @@ export function fromTimestamp(timestamp: bigint): number {
  */
 export function endOfMs(ms: number): bigint {
   return toTimestamp(Math.floor(ms) + 1);
+}
+
+declare const Convex: {
+  syscall: (op: string, jsonArgs: string) => string;
+};
+
+/**
+ * The timestamp of the snapshot this transaction reads from, in nanoseconds on
+ * the commit-timestamp clock. Every transaction stamped at or below it is
+ * visible to this one, and every transaction that commits after it — whether
+ * or not it has started yet — is stamped above it. So it is the highest value
+ * a cursor over a commit-ordered index can advance to without passing
+ * something it hasn't read.
+ *
+ * TODO(convex): replace with `ctx.meta.getSnapshotTs()` once a released
+ * `convex` exposes it; this is the syscall it wraps.
+ */
+export function snapshotTs(): bigint {
+  const json = Convex.syscall("1.0/getSnapshotTs", "{}");
+  return jsonToConvex(JSON.parse(json)) as bigint;
 }
 
 // Nanoseconds for the year 2000: far above any 100ms bucket an older version

--- a/src/component/stateMachine.test.ts
+++ b/src/component/stateMachine.test.ts
@@ -367,8 +367,8 @@ describe("state machine", () => {
 
   /**
    * Drive one loop iteration the way batch-worker does. The empty commit
-   * carries the clock change into the database: the loop's eligibility bound
-   * is its snapshot timestamp, which in convex-test is the latest commit.
+   * carries the clock change into convex-test's snapshot, which only advances
+   * on commit.
    */
   async function runLoop(segment: bigint) {
     vi.setSystemTime(fromSegment(segment));

--- a/src/component/stateMachine.test.ts
+++ b/src/component/stateMachine.test.ts
@@ -365,9 +365,14 @@ describe("state machine", () => {
     });
   }
 
-  /** Drive one loop iteration the way batch-worker does. */
+  /**
+   * Drive one loop iteration the way batch-worker does. The empty commit
+   * carries the clock change into the database: the loop's eligibility bound
+   * is its snapshot timestamp, which in convex-test is the latest commit.
+   */
   async function runLoop(segment: bigint) {
     vi.setSystemTime(fromSegment(segment));
+    await t.run(async () => {});
     const result = await t.query(internal.loop.getBatch, {
       name: WORKER_NAME,
     });

--- a/src/component/stateMachine.test.ts
+++ b/src/component/stateMachine.test.ts
@@ -365,14 +365,9 @@ describe("state machine", () => {
     });
   }
 
-  /**
-   * Drive one loop iteration the way batch-worker does. The empty commit
-   * carries the clock change into convex-test's snapshot, which only advances
-   * on commit.
-   */
+  /** Drive one loop iteration the way batch-worker does. */
   async function runLoop(segment: bigint) {
     vi.setSystemTime(fromSegment(segment));
-    await t.run(async () => {});
     const result = await t.query(internal.loop.getBatch, {
       name: WORKER_NAME,
     });

--- a/src/component/stats.test.ts
+++ b/src/component/stats.test.ts
@@ -51,7 +51,6 @@ describe("stats", () => {
       // Setup internal state
       const stateId = await t.run(async (ctx) => {
         return await ctx.db.insert("internalState", {
-          generation: 1n,
           segmentCursors: {
             incoming: 0n,
             completion: 0n,
@@ -96,7 +95,6 @@ describe("stats", () => {
       // Setup internal state
       const stateId = await t.run(async (ctx) => {
         return await ctx.db.insert("internalState", {
-          generation: 1n,
           segmentCursors: {
             incoming: 0n,
             completion: 0n,
@@ -170,7 +168,6 @@ describe("stats", () => {
       // Setup internal state
       const stateId = await t.run(async (ctx) => {
         return await ctx.db.insert("internalState", {
-          generation: 1n,
           segmentCursors: {
             incoming: 0n,
             completion: 0n,
@@ -254,7 +251,6 @@ describe("stats", () => {
       // Setup internal state
       const stateId = await t.run(async (ctx) => {
         return await ctx.db.insert("internalState", {
-          generation: 1n,
           segmentCursors: {
             incoming: 0n,
             completion: 0n,

--- a/src/component/stats.ts
+++ b/src/component/stats.ts
@@ -8,7 +8,7 @@ import {
 import {
   type Config,
   DEFAULT_MAX_PARALLELISM,
-  snapshotTs,
+  eligibilityBound,
   WORKER_NAME,
 } from "./shared.js";
 import { createLogger, type Logger, logLevel, shouldLog } from "./logging.js";
@@ -77,14 +77,14 @@ export async function generateReport(
     // Don't waste time if we're not going to log.
     return;
   }
-  // Backlog is work that's eligible now; anything scheduled for later sorts
-  // above the snapshot and isn't waiting on us.
+  // Backlog is work that's eligible now; anything scheduled for later isn't
+  // waiting on us.
   const pendingStart = await paginator(ctx.db, schema)
     .query("pendingStart")
     .withIndex("segment", (q) =>
       q
         .gte("segment", state.segmentCursors.incoming)
-        .lte("segment", snapshotTs()),
+        .lte("segment", eligibilityBound()),
     )
     .paginate({
       numItems: Math.max(maxParallelism, 10),

--- a/src/component/stats.ts
+++ b/src/component/stats.ts
@@ -8,7 +8,7 @@ import {
 import {
   type Config,
   DEFAULT_MAX_PARALLELISM,
-  endOfMs,
+  snapshotTs,
   WORKER_NAME,
 } from "./shared.js";
 import { createLogger, type Logger, logLevel, shouldLog } from "./logging.js";
@@ -78,13 +78,13 @@ export async function generateReport(
     return;
   }
   // Backlog is work that's eligible now; anything scheduled for later sorts
-  // above the current time and isn't waiting on us.
+  // above the snapshot and isn't waiting on us.
   const pendingStart = await paginator(ctx.db, schema)
     .query("pendingStart")
     .withIndex("segment", (q) =>
       q
         .gte("segment", state.segmentCursors.incoming)
-        .lt("segment", endOfMs(Date.now())),
+        .lte("segment", snapshotTs()),
     )
     .paginate({
       numItems: Math.max(maxParallelism, 10),


### PR DESCRIPTION
bound the incoming cursor by the snapshot timestamp

The loop capped its incoming cursor at the newest commit stamp it had
observed, assembled from the previous run's own commit (lastCommitTs), the
completions and cancelations it read, ready pendingStart documents, and the
sweep. Telling a ready document's commit stamp from a scheduled one's
wall-clock key needed a `scheduled` marker on every entry.

The snapshot timestamp is the frontier those approximated: everything
stamped at or below it is visible, everything committing later is stamped
above it. Read it once in getBatch and cap the cursor there. Drop
lastCommitTs, the scheduled flag, and the stamp collection; the guard
against moving the cursor backwards is no longer reachable.

The scanTs sweep is unchanged: it rescues documents that are visible but
keyed below the cursor, which no bound on unseen commits can cover.

snapshotTs() calls the 1.0/getSnapshotTs syscall directly until a released
convex exposes ctx.meta.getSnapshotTs(). convex-test comes from a pkg.pr.new
build that answers the syscall.

make the snapshot the eligibility bound

The segment scan read up to the end of the current wall-clock millisecond
and the cursor was then capped at the snapshot. Reading up to the snapshot
instead means every key the scan sees is at or below it, so the cursor can
rest on the last handled key and the cap goes away. Ready work is eligible
as soon as it is visible, whatever the two clocks do relative to each other.

Scheduled work and retries now come due by the commit clock. The keys the
loop writes itself, a retry's backoff and a legacy entry's re-key, are
raised to at least the snapshot, since the cursor can now reach it within
the same run.

endOfMs is gone with the wall-clock bound; a sub-millisecond runAt is stored
exactly and starts within the next millisecond. The test drivers commit
before each iteration so the fake clock reaches convex-test's snapshot the
way batch-worker's own commits do in production.

raise scheduled enqueue keys to the enqueuer's snapshot

The loop already raised the keys it writes (retry backoffs, legacy re-keys)
to at least its snapshot. Scheduled enqueues now do the same with theirs,
so every writer follows one rule: no key below its writer's snapshot. Ready
enqueues satisfy it already, since the commit stamp is above the snapshot
by definition.

This doesn't replace the scanTs sweep, because an enqueue in flight while
the loop reads can still commit a key below the loop's cursor. It does
bound how far behind such a key can land to that in-flight window, rather
than to however far the wall clock trails the commit clock.

depend on the published convex-test alpha

convex-test@0.0.57-alpha.0 answers the 1.0/getSnapshotTs syscall, replacing
the pkg.pr.new build.

read the snapshot where it's used

getBatch and run share a transaction, so the snapshot timestamp is the same
in both; carrying it in the batch and threading it through handleCompletions,
rescheduleJob, and promoteScheduled added parameters without information.
Each site reads it directly, and the segment scan explains why it is the
eligibility bound.